### PR TITLE
Remove 'rspec' as minitest dependency, add 'minitest'

### DIFF
--- a/Testing.md
+++ b/Testing.md
@@ -231,7 +231,7 @@ Add this gem to your Gemfile in the `test` group:
 ```ruby
 group :test do
   gem 'karafka-testing'
-  gem 'rspec'
+  gem 'minitest'
 end
 ```
 


### PR DESCRIPTION
I think we should either remove rspec or change to minitest