### PR TITLE
Document `force_ruby_platform: true` to force compiling from source

### DIFF
--- a/Development/Native-Extensions.md
+++ b/Development/Native-Extensions.md
@@ -194,7 +194,7 @@ If native extensions don't work for your platform:
 gem install rdkafka --platform=ruby
 
 # Or in Gemfile
-gem 'rdkafka', platforms: [:ruby]
+gem 'rdkafka', force_ruby_platform: true
 ```
 
 ## Source Compilation (Fallback)
@@ -208,7 +208,7 @@ If you need to use source compilation instead of native extensions (e.g., for cu
 gem install rdkafka --platform=ruby
 
 # Or in Gemfile
-gem 'rdkafka', platforms: [:ruby]
+gem 'rdkafka', force_ruby_platform: true
 ```
 
 ## Migration from Source Compilation


### PR DESCRIPTION
Hello dear maintainers 👋

While updating `rdkafka` from 0.21.0 to 0.22.2 for an app running on Debian 11 (which has no precompiled gem available), I noticed that the "Native Extensions" troubleshooting documentation may be incorrect about how to force compilation from source.

The current example:

```ruby
gem 'rdkafka', platforms: [:ruby]
``` 

does not force compilation. Instead, `platforms: [:ruby]` tells Bundler to install the gem only on matching platforms — similar to Gemfile groups — as documented in [Bundler’s platforms](https://bundler.io/man/gemfile.5.html#PLATFORMS) section.

I _think_ the correct way to force compilation from source is:
```ruby 
gem 'rdkafka', force_ruby_platform: true
```

`force_ruby_platform` ensures Bundler always selects the pure-Ruby variant (triggering native extension compilation when no precompiled version exists). See [Bundler docs](https://bundler.io/man/gemfile.5.html#FORCE_RUBY_PLATFORM).

There's a second mention of the `platforms` options in the “[force precompiled gem installation.](https://karafka.io/docs/Development-Native-Extensions/#force-native-extension-installation)” entry. I believe this is also incorrect, but I couldn’t find a Gemfile option that explicitly fails when no precompiled version exists — so the fix there is less clear.
