### PR TITLE
Enhance README with GitHub Wiki sync docs and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,42 +2,58 @@
 
 The documentation repository for the [Karafka](https://karafka.io) ecosystem - a Ruby and Rails efficient Kafka processing framework.
 
-## What is this repository?
+## What is This Repository?
 
-This repository contains all the documentation for Karafka and its related components, organized as a collection of Markdown files that are automatically processed and deployed
+This repository contains all the documentation for Karafka and its related components, organized as a collection of Markdown files that are automatically processed and deployed to [karafka.io/docs](https://karafka.io/docs/).
 
 ## Automated Content Management
 
-This repository includes several automated processes to keep documentation current and consistent:
+This repository includes several automated processes to keep documentation current and consistent.
 
 ### Automatic Content Refresh
 
-The repository automatically fetches and updates dynamic content twice daily (6:00 AM and 6:00 PM UTC) and on-demand through repository dispatch events:
+The repository automatically fetches and updates dynamic content daily at 6:00 AM UTC and on-demand through repository dispatch events:
 
-- **Component Changelogs**: Automatically pulls the latest CHANGELOG.md files from all Karafka ecosystem repositories
+- **Component Changelogs**: Pulls the latest CHANGELOG.md files from all Karafka ecosystem repositories
 - **librdkafka Releases**: Fetches and formats librdkafka release information from GitHub
-- **Error Documentation**: Generates comprehensive librdkafka error reference documentation
+- **librdkafka Documentation**: Generates error reference, statistics, and configuration documentation
+
+### GitHub Wiki Sync
+
+The documentation is automatically mirrored to the [GitHub Wiki](https://github.com/karafka/karafka/wiki) on every merge to master. The sync process:
+
+- Copies and flattens the directory structure for GitHub Wiki compatibility
+- Adds a header to each page directing users to the main documentation site
+- Removes stale pages that no longer exist in the source
+- Preserves wiki-specific files like `_Footer.md` and `_Sidebar.md`
+
+The header template is located in `.gh-templates/_GH_Header.md`.
 
 ### Content Processing Scripts
 
 Located in the `bin/` directory:
 
-- `refresh_remote_content` - Downloads changelogs and commercial license from component repositories
-- `refresh_librdkafka_errors` - Generates librdkafka error documentation dynamically using the rdkafka gem
-- `refresh_librdkafka_releases` - Generates librdkafka releases documentation dynamically based on the official releases
-- `refresh_librdkafka_statistics` - Generates librdkafka statistics documentation based on the official docs
-- `refresh_librdkafka_configuration` - Generates librdkafka configuration documentation based on the official docs
-- `align_structure` - Flattens nested documentation structure and fixes cross-references for MkDocs compatibility
-- `mklint` - Validates documentation structure, references, and builds using MkDocs in strict mode
-- `sync_gh` - Synchronizes content with GitHub Karafka main repo
+| Script | Description |
+| ------ | ----------- |
+| `refresh_remote_content` | Downloads changelogs and commercial license from component repositories |
+| `refresh_librdkafka_errors` | Generates librdkafka error documentation using the rdkafka gem |
+| `refresh_librdkafka_releases` | Generates librdkafka releases documentation from GitHub |
+| `refresh_librdkafka_statistics` | Generates librdkafka statistics documentation |
+| `refresh_librdkafka_configuration` | Generates librdkafka configuration documentation |
+| `refresh_karafka_integrations_catalog` | Generates integration tests catalog |
+| `refresh_instrumentation_events` | Generates instrumentation events documentation |
+| `align_structure` | Flattens nested documentation structure for MkDocs compatibility |
+| `mklint` | Validates documentation structure, references, and builds with MkDocs |
+| `sync_gh` | Synchronizes content with the GitHub Wiki |
 
 ### Continuous Integration
 
 The CI pipeline ensures documentation quality through:
 
-- **Markdown Linting**: Uses `markdownlint-cli2` to enforce consistent Markdown formatting
-- **Structure Validation**: Validates cross-references, anchor links, and overall documentation structure
-- **Security**: Verifies all GitHub Actions use SHA-pinned versions for security
+- **Markdown Linting**: Uses `markdownlint-cli2` to enforce consistent formatting
+- **Structure Validation**: Validates cross-references, anchor links, and documentation structure
+- **MkDocs Build**: Builds documentation in strict mode to catch errors
+- **Security**: Verifies all GitHub Actions use SHA-pinned versions
 
 ### Pull Request Automation
 
@@ -46,7 +62,7 @@ When automatic content updates are available, the system:
 1. Fetches the latest content from all sources
 2. Regenerates dynamic documentation
 3. Creates a pull request with the changes
-4. Maintains a clean commit history with automated updates
+4. Maintains a clean commit history
 
 ## Auto-Generated Content
 
@@ -55,13 +71,13 @@ Several files in this repository are automatically generated and should not be e
 - `Changelog/*.md` - Component changelogs
 - `Librdkafka/Changelog.md` - librdkafka release notes
 - `Librdkafka/Errors.md` - librdkafka error reference
+- `Librdkafka/Statistics.md` - librdkafka statistics documentation
+- `Librdkafka/Configuration.md` - librdkafka configuration documentation
+- `Development/Karafka-Integration-Tests-Catalog.md` - Integration tests catalog
+- `Operations/Instrumentation-Events.md` - Instrumentation events
+- `WaterDrop/Instrumentation-Events.md` - WaterDrop instrumentation events
 
-These files include header comments indicating their auto-generated status:
-
-```markdown
-[//]: # (This file is auto-generated by bin/refresh_remote_content)
-[//]: # (Do not edit manually - changes will be overwritten)
-```
+These files include header comments indicating their auto-generated status.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add new section documenting the automatic GitHub Wiki synchronization feature
- Update auto-generated content list to include all generated files (Statistics, Configuration, Integration Tests, Instrumentation Events)
- Convert scripts list from bullet points to table format for better readability
- Add link to the main documentation site (karafka.io/docs)
- Minor wording and formatting improvements throughout

## Test plan
- [x] Linting passes
- [x] Review README rendering on GitHub