### PR TITLE
docs: update Ruby 3.5 to 4.0 in version support table

### DIFF
--- a/Advanced/Versions-Lifecycle-and-EOL.md
+++ b/Advanced/Versions-Lifecycle-and-EOL.md
@@ -69,7 +69,7 @@ We officially provide support for all the versions of Ruby that are not EOL, and
 
 | Version | Status      | EOL date   |
 |---------|-------------|------------|
-| 3.5     | Preview     | 2029-09-30 |
+| 4.0     | Preview     | 2029-09-30 |
 | 3.4     | Active      | 2028-09-30 |
 | 3.3     | Active      | 2027-09-30 |
 | 3.2     | Active      | 2026-09-30 |


### PR DESCRIPTION
## Summary
- Updates Ruby version reference from 3.5 to 4.0 in the Ruby Versions Support table
- Ruby 3.5 has been renamed to Ruby 4.0

## Test plan
- [x] Linting passes
- [x] No other Ruby 3.5 references in the documentation