### PR TITLE
Expand KIP-932 rdkafka-ruby development documentation

### DIFF
--- a/Development/KIP-932-Rdkafka.md
+++ b/Development/KIP-932-Rdkafka.md
@@ -6,7 +6,7 @@
 
 KIP-932 introduces **Share Groups**, a new consumption model for Kafka that enables queue-like semantics. Unlike traditional consumer groups where each partition is assigned to exactly one consumer, share groups allow multiple consumers to cooperatively consume from the same partitions without exclusive assignment.
 
-This document analyzes the changes required in rdkafka-ruby to support KIP-932, serving as the foundation layer that Karafka and karafka-web depend on.
+This document analyzes the changes required in rdkafka-ruby to support KIP-932.
 
 ## Critical Dependency: librdkafka
 
@@ -16,9 +16,8 @@ rdkafka-ruby is an FFI wrapper around librdkafka. **All KIP-932 functionality de
 | --------- | ------ | ----- |
 | librdkafka KIP-932 | Not started | No public issues or PRs as of research date |
 | rdkafka-ruby bindings | Blocked | Waiting for librdkafka implementation |
-| Karafka integration | Design phase | See KIP-932-Karafka.md |
 
-Once librdkafka implements KIP-932, rdkafka-ruby will need to expose the new C APIs through FFI bindings.
+Once librdkafka implements KIP-932, rdkafka-ruby will need to expose the new APIs through FFI bindings.
 
 ## KIP-932 Overview
 
@@ -47,13 +46,12 @@ Share groups represent a new consumption model where:
 
 - `ShareFetch` / `ShareAcknowledge` RPCs
 - `ShareGroupHeartbeat` for membership management
-- `KafkaShareConsumer` client interface (Java reference)
 - Internal topic: `__share_group_state`
 - Offsets: SPSO (Share-Partition Start Offset), SPEO (Share-Partition End Offset)
 
 ## Current rdkafka-ruby Architecture
 
-### FFI Binding Structure
+### Consumer Structure
 
 rdkafka-ruby uses Ruby FFI to bind to librdkafka's C API:
 
@@ -72,13 +70,6 @@ Rdkafka::Consumer
 ├── pause/resume(topic_partition_list)
 ├── seek(topic_partition)
 └── close()
-
-Rdkafka::Bindings (FFI)
-├── rd_kafka_subscribe()
-├── rd_kafka_consumer_poll()
-├── rd_kafka_commit()
-├── rd_kafka_offset_store()
-└── ... (other librdkafka functions)
 ```
 
 ### Statistics Callback
@@ -122,133 +113,46 @@ end
 
 ## Required librdkafka APIs
 
-For rdkafka-ruby to support KIP-932, librdkafka must expose these C APIs:
+For rdkafka-ruby to support KIP-932, librdkafka must expose APIs for:
 
-### Share Consumer Creation
+- **Share group subscription** - Subscribe to topics as a share group
+- **Acknowledgment** - ACCEPT, RELEASE, or REJECT individual records
+- **Batch acknowledgment** - Acknowledge multiple records at once
+- **Commit** - Commit pending acknowledgments (for explicit mode)
+- **Delivery attempt** - Get the delivery attempt count for a message
+- **Statistics** - Share group metrics in the statistics JSON
 
-```c
-// New consumer type or configuration option
-rd_kafka_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf);
-// OR
-// Flag/config to create share consumer from existing rd_kafka_new()
-```
+The exact API signatures will depend on librdkafka's implementation decisions.
 
-### Share Group Subscription
+## API Design: Extended Consumer Class
 
-```c
-// Subscribe to topics as share group
-rd_kafka_resp_err_t rd_kafka_share_subscribe(
-    rd_kafka_t *rk,
-    const rd_kafka_topic_partition_list_t *topics
-);
-```
+Following librdkafka's approach, rdkafka-ruby will extend the existing `Consumer` class rather than creating a separate class. The group type is determined by configuration.
 
-### Polling
-
-```c
-// Poll for messages (may reuse existing rd_kafka_consumer_poll)
-rd_kafka_message_t *rd_kafka_share_consumer_poll(
-    rd_kafka_t *rk,
-    int timeout_ms
-);
-```
-
-### Acknowledgment
-
-```c
-// Acknowledge individual record
-rd_kafka_resp_err_t rd_kafka_share_acknowledge(
-    rd_kafka_t *rk,
-    rd_kafka_message_t *message,
-    rd_kafka_share_ack_type_t type  // ACCEPT, RELEASE, REJECT
-);
-
-// Batch acknowledgment
-rd_kafka_resp_err_t rd_kafka_share_acknowledge_batch(
-    rd_kafka_t *rk,
-    rd_kafka_message_t **messages,
-    size_t count,
-    rd_kafka_share_ack_type_t type
-);
-
-// Commit acknowledgments (implicit or explicit mode)
-rd_kafka_resp_err_t rd_kafka_share_commit(rd_kafka_t *rk);
-rd_kafka_resp_err_t rd_kafka_share_commit_async(rd_kafka_t *rk);
-```
-
-### Message Metadata
-
-```c
-// Get delivery attempt count for message
-int rd_kafka_message_delivery_attempt(const rd_kafka_message_t *message);
-```
-
-### Statistics Extensions
-
-librdkafka statistics JSON must include share group data:
-
-```json
-{
-  "sgrp": {
-    "state": "stable",
-    "stateage": 12345678,
-    "member_id": "rdkafka-xxx",
-    "topics": {
-      "my-topic": {
-        "partitions": {
-          "0": {
-            "spso": 1000,
-            "speo": 1500,
-            "in_flight": 50,
-            "acquired": 25,
-            "acknowledged": 975
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-## FFI Binding Changes
-
-### New FFI Functions
+### New Consumer Methods
 
 ```ruby
 module Rdkafka
-  module Bindings
-    extend FFI::Library
+  class Consumer
+    # Existing methods remain unchanged...
 
-    # Acknowledgment types enum
-    enum :share_ack_type, [
-      :accept, 0,
-      :release, 1,
-      :reject, 2
-    ]
+    # NEW: Share group acknowledgment
+    # @param message [Message] The message to acknowledge
+    # @param type [Symbol] :accept, :release, or :reject
+    def acknowledge(message, type = :accept)
+      # FFI call to librdkafka acknowledge function
+    end
 
-    # Share group acknowledgment
-    attach_function :rd_kafka_share_acknowledge,
-      [:pointer, :pointer, :share_ack_type],
-      :int
+    # NEW: Batch acknowledgment
+    # @param messages [Array<Message>] Messages to acknowledge
+    # @param type [Symbol] :accept, :release, or :reject
+    def acknowledge_batch(messages, type = :accept)
+      # FFI call to librdkafka batch acknowledge function
+    end
 
-    # Batch acknowledgment
-    attach_function :rd_kafka_share_acknowledge_batch,
-      [:pointer, :pointer, :size_t, :share_ack_type],
-      :int
-
-    # Share commit
-    attach_function :rd_kafka_share_commit,
-      [:pointer],
-      :int
-
-    attach_function :rd_kafka_share_commit_async,
-      [:pointer],
-      :int
-
-    # Delivery attempt accessor
-    attach_function :rd_kafka_message_delivery_attempt,
-      [:pointer],
-      :int
+    # NEW: Check if this consumer is using a share group
+    def share_group?
+      # Check group.type config
+    end
   end
 end
 ```
@@ -273,127 +177,6 @@ module Rdkafka
 end
 ```
 
-## API Design Options
-
-### Option A: Separate ShareConsumer Class
-
-Create a dedicated `Rdkafka::ShareConsumer` class:
-
-```ruby
-module Rdkafka
-  class ShareConsumer
-    def initialize(native_kafka, config)
-      @native_kafka = native_kafka
-      @config = config
-    end
-
-    def subscribe(topics)
-      # Share group subscription
-    end
-
-    def poll(timeout_ms = 250)
-      # Returns message with delivery_attempt
-    end
-
-    def each(timeout_ms: 250)
-      loop do
-        message = poll(timeout_ms)
-        yield message if message
-      end
-    end
-
-    def acknowledge(message, type = :accept)
-      # ACCEPT, RELEASE, or REJECT
-    end
-
-    def acknowledge_batch(messages, type = :accept)
-      # Batch acknowledgment
-    end
-
-    def commit
-      # Commit pending acknowledgments (explicit mode)
-    end
-
-    def commit_async
-      # Async commit
-    end
-
-    def close
-      # Cleanup
-    end
-
-    # NOT available (raise helpful error):
-    # - store_offset (no offset management)
-    # - seek (no offset-based consumption)
-    # - pause/resume on partitions (no exclusive ownership)
-  end
-end
-```
-
-**Config creation:**
-
-```ruby
-config = Rdkafka::Config.new(
-  'bootstrap.servers': 'localhost:9092',
-  'group.id': 'my-share-group',
-  'group.type': 'share'  # New config option
-)
-share_consumer = config.share_consumer
-```
-
-### Option B: Extend Existing Consumer
-
-Add share group methods to `Rdkafka::Consumer`:
-
-```ruby
-module Rdkafka
-  class Consumer
-    # Existing methods...
-
-    # NEW: Share group methods
-    def acknowledge(message, type = :accept)
-      raise_unless_share_group!
-      # ...
-    end
-
-    def share_group?
-      @config['group.type'] == 'share'
-    end
-
-    private
-
-    def raise_unless_share_group!
-      raise Rdkafka::ShareGroupRequiredError unless share_group?
-    end
-  end
-end
-```
-
-### Recommended Approach: Option A (Separate Class)
-
-**Rationale:**
-
-- **Clear separation**: Consumer groups and share groups have fundamentally different semantics
-- **No method guards**: Methods only exist where they apply
-- **Type safety**: Harder to accidentally call wrong methods
-- **Follows librdkafka pattern**: Java has separate `KafkaConsumer` and `KafkaShareConsumer`
-- **Easier testing**: Each class has focused responsibility
-
-## New Methods
-
-### ShareConsumer Methods
-
-| Method | Description | Returns |
-| ------ | ----------- | ------- |
-| `subscribe(topics)` | Subscribe to topics as share group | `nil` |
-| `poll(timeout_ms)` | Poll for single message | `Message` or `nil` |
-| `each(timeout_ms:)` | Iterate over messages | yields `Message` |
-| `acknowledge(message, type)` | Acknowledge single record | `nil` |
-| `acknowledge_batch(messages, type)` | Acknowledge multiple records | `nil` |
-| `commit` | Commit pending acknowledgments | `nil` |
-| `commit_async` | Async commit | `nil` |
-| `close` | Close consumer | `nil` |
-
 ### Message Extensions
 
 ```ruby
@@ -402,10 +185,10 @@ module Rdkafka
     # NEW: Delivery attempt count (share groups)
     # Returns 1 for first delivery, increments on redelivery
     def delivery_attempt
-      Bindings.rd_kafka_message_delivery_attempt(@native_message)
+      # FFI call to get delivery attempt from native message
     end
 
-    # NEW: Check if redelivered
+    # NEW: Check if this is a redelivered message
     def redelivered?
       delivery_attempt > 1
     end
@@ -413,22 +196,39 @@ module Rdkafka
 end
 ```
 
+### Method Availability
+
+When using a share group consumer, certain methods don't apply:
+
+| Method | Consumer Group | Share Group |
+| ------ | -------------- | ----------- |
+| `subscribe` | Yes | Yes |
+| `poll` | Yes | Yes |
+| `each` | Yes | Yes |
+| `commit` | Yes | Yes (commits acknowledgments) |
+| `acknowledge` | No | Yes |
+| `acknowledge_batch` | No | Yes |
+| `store_offset` | Yes | No (raises error) |
+| `seek` | Yes | No (raises error) |
+| `pause/resume` | Yes | No (raises error) |
+
+Methods that don't apply to share groups will raise a descriptive error when called.
+
 ## Statistics Exposure
 
 ### Share Group Statistics Structure
 
-When librdkafka exposes share group statistics, rdkafka-ruby will parse them similarly to consumer group stats:
+When librdkafka exposes share group statistics, they will likely appear in a separate section (e.g., `sgrp`) from consumer group stats (`cgrp`):
 
 ```ruby
-# Statistics callback receives parsed JSON
 config.consumer_statistics_callback = ->(stats) {
   if stats['sgrp']  # Share group stats
     sg = stats['sgrp']
     puts "Share group state: #{sg['state']}"
     puts "Member ID: #{sg['member_id']}"
 
-    sg['topics'].each do |topic, topic_stats|
-      topic_stats['partitions'].each do |partition_id, p_stats|
+    sg['topics']&.each do |topic, topic_stats|
+      topic_stats['partitions']&.each do |partition_id, p_stats|
         puts "#{topic}[#{partition_id}]:"
         puts "  SPSO: #{p_stats['spso']}"
         puts "  SPEO: #{p_stats['speo']}"
@@ -473,21 +273,9 @@ module Rdkafka
   class RdkafkaError < StandardError
     # Existing error codes...
 
-    # NEW: Share group error codes
-    SHARE_SESSION_NOT_FOUND = -XXX
-    SHARE_PARTITION_NOT_FOUND = -XXX
-    INVALID_SHARE_SESSION_EPOCH = -XXX
-    FENCED_STATE_EPOCH = -XXX
-    INVALID_RECORD_STATE = -XXX
-
+    # NEW: Helper to check if error is share group related
     def share_group_error?
-      [
-        SHARE_SESSION_NOT_FOUND,
-        SHARE_PARTITION_NOT_FOUND,
-        INVALID_SHARE_SESSION_EPOCH,
-        FENCED_STATE_EPOCH,
-        INVALID_RECORD_STATE
-      ].include?(code)
+      # Check against share group error codes
     end
   end
 end
@@ -520,7 +308,7 @@ config = Rdkafka::Config.new(
   'group.share.session.timeout.ms': 45000
 )
 
-share_consumer = config.share_consumer
+consumer = config.consumer
 ```
 
 ### Acknowledgment Mode
@@ -544,90 +332,10 @@ config = Rdkafka::Config.new(
 )
 ```
 
-## Integration with Karafka
-
-### Karafka Client Layer
-
-Karafka's `Connection::Client` will wrap the new `ShareConsumer`:
-
-```ruby
-# lib/karafka/connection/client.rb
-module Karafka
-  module Connection
-    class Client
-      def initialize(subscription_group)
-        @subscription_group = subscription_group
-
-        if subscription_group.share_group?
-          @kafka = build_share_consumer
-        else
-          @kafka = build_consumer
-        end
-      end
-
-      # NEW: Share group acknowledgment
-      def acknowledge(message, type = :accept)
-        @kafka.acknowledge(message, type)
-      end
-
-      def share_group?
-        @subscription_group.share_group?
-      end
-
-      private
-
-      def build_share_consumer
-        Rdkafka::Config.new(kafka_config).share_consumer
-      end
-
-      def build_consumer
-        Rdkafka::Config.new(kafka_config).consumer
-      end
-    end
-  end
-end
-```
-
-### Message Delivery Attempt
-
-Karafka's `Message` class will delegate to rdkafka-ruby:
-
-```ruby
-# lib/karafka/messages/message.rb
-class Message
-  def delivery_attempt
-    # Delegates to rdkafka-ruby message
-    @raw_message.delivery_attempt
-  end
-
-  def redelivered?
-    delivery_attempt > 1
-  end
-end
-```
-
-### Statistics Flow
-
-karafka-web consumes statistics from rdkafka-ruby's callback:
-
-```text
-librdkafka statistics (JSON)
-    ↓
-rdkafka-ruby callback (parsed Hash)
-    ↓
-Karafka instrumentation events
-    ↓
-karafka-web sampler/listeners
-    ↓
-Web UI display
-```
-
-Share group statistics will flow through the same pipeline, requiring karafka-web to handle the different `sgrp` structure (see KIP-932-Web-UI.md).
-
 ## Usage Example
 
 ```ruby
-# Create share consumer
+# Create share group consumer
 config = Rdkafka::Config.new(
   'bootstrap.servers': 'localhost:9092',
   'group.id': 'job-processors',
@@ -635,22 +343,22 @@ config = Rdkafka::Config.new(
   'share.acknowledgement.mode': 'explicit'
 )
 
-share_consumer = config.share_consumer
-share_consumer.subscribe(['jobs'])
+consumer = config.consumer
+consumer.subscribe(['jobs'])
 
 # Process messages
-share_consumer.each do |message|
+consumer.each do |message|
   puts "Processing job (attempt #{message.delivery_attempt})"
 
   begin
     process_job(message.payload)
-    share_consumer.acknowledge(message, :accept)
+    consumer.acknowledge(message, :accept)
   rescue TransientError
     # Release for immediate redelivery to any consumer
-    share_consumer.acknowledge(message, :release)
+    consumer.acknowledge(message, :release)
   rescue PermanentError
     # Reject - won't be redelivered (archived after max attempts)
-    share_consumer.acknowledge(message, :reject)
+    consumer.acknowledge(message, :reject)
   end
 end
 ```
@@ -659,14 +367,12 @@ end
 
 ### librdkafka Design Dependencies
 
-- Will librdkafka expose a separate `rd_kafka_share_consumer_*` API or extend existing consumer API?
 - What will the statistics JSON structure look like for share groups?
 - Will there be new callbacks for share group events (member joined, etc.)?
 - How will librdkafka handle implicit vs explicit acknowledgment mode?
 
 ### rdkafka-ruby API Decisions
 
-- Should `ShareConsumer` share a base class with `Consumer` for common functionality?
 - How should batch acknowledgment handle partial failures?
 - Should statistics parsing be unified or separate for consumer/share groups?
 
@@ -675,19 +381,3 @@ end
 - Minimum librdkafka version required for KIP-932?
 - Kafka broker version requirements (4.0+)?
 - Will there be feature detection for share group support?
-
-## Timeline Dependencies
-
-```text
-1. librdkafka implements KIP-932 APIs
-   ↓
-2. rdkafka-ruby adds FFI bindings
-   ↓
-3. rdkafka-ruby adds ShareConsumer class
-   ↓
-4. Karafka adds share_group routing DSL
-   ↓
-5. karafka-web adds share group UI support
-```
-
-Each layer depends on the previous. Monitor librdkafka development for progress on KIP-932 implementation.


### PR DESCRIPTION
## Summary

- Synthesize comprehensive development documentation for KIP-932 Share Groups support in rdkafka-ruby
- Cover all aspects: FFI bindings, API design, statistics, configuration, and error handling
- Bridge the gap between librdkafka and the higher-level Karafka/karafka-web docs

## Key Sections

- **Critical Dependency**: librdkafka must implement KIP-932 first
- **Required librdkafka APIs**: New C APIs needed for FFI bindings
- **API Design Options**: Recommends separate `ShareConsumer` class
- **FFI Binding Changes**: New functions and constants
- **Statistics Exposure**: Share group metrics structure
- **Error Handling**: New error codes for share groups
- **Configuration Options**: Share group specific settings
- **Integration with Karafka**: How Karafka::Connection::Client will use new APIs

## Test plan

- [x] Run `npm run lint` - passes with 0 errors
- [ ] Review document structure matches sibling KIP-932 docs
- [ ] Verify technical accuracy of proposed APIs