### PR TITLE
docs: add karafka-web v0.11.6 feature documentation

### DIFF
--- a/Pro/Web-UI/Commanding.md
+++ b/Pro/Web-UI/Commanding.md
@@ -16,6 +16,10 @@ Commanding is **turned on by default**. During each consumer process startup, it
 
 To turn off this feature, you can set the `config.commanding.active` configuration option to `false`. Disabling commanding removes the extra Kafka connection dedicated to these administrative tasks. Consequently, it also disables the ability to execute these commands from the Web UI.
 
+!!! warning "Commands Topic Required"
+
+    The commanding feature requires the `karafka_consumers_commands` topic to be present in your Kafka cluster. If this topic is missing, the Web UI will display an alert notifying you that pause, resume, and trace functionality is unavailable. Ensure this topic exists and is properly configured before attempting to use commanding features.
+
 ```ruby
 # Completely disable commanding from Web UI
 Karafka::Web.setup do |config|
@@ -142,6 +146,37 @@ Partition-level controls are accessible from two main locations:
 </p>
 
 ### Pause and Resume Partitions
+
+The partition pause feature allows you to temporarily stop message processing for specific partitions without stopping the entire consumer process. Karafka provides two levels of pause control:
+
+- **Partition-level**: Pause individual partitions one at a time
+- **Topic-level**: Pause all partitions of a topic at once across all consumer processes
+
+#### Topic-Level Pause/Resume
+
+For scenarios where you need to pause all partitions of a topic simultaneously, Karafka provides topic-level pause controls accessible from the Health Overview page.
+
+To pause all partitions of a topic:
+
+1. Navigate to **Health → Overview**
+2. Locate the topic you want to pause
+3. Click the **Pause Topic** button
+4. Configure pause settings (duration and safety options)
+5. Confirm the operation
+
+The command is broadcast to all consumer processes, with each process applying the pause to the partitions it owns within the specified consumer group. This is particularly useful for:
+
+- **Coordinated maintenance**: Stopping all processing for a topic during planned maintenance
+- **Emergency response**: Quickly halting all consumption when issues are detected
+- **Resource management**: Freeing up resources across all consumers processing a topic
+
+To resume all paused partitions of a topic, use the corresponding **Resume Topic** button from the same Health Overview interface.
+
+!!! info "Cross-Process Coordination"
+
+    Topic-level pause/resume commands are distributed to all active consumer processes. Each process will apply the command only to the partitions it currently owns. This ensures consistent behavior across your consumer fleet without requiring manual intervention on each process.
+
+#### Partition-Level Pause/Resume
 
 The partition pause feature allows you to temporarily stop message processing for a specific partition without stopping the entire consumer process.
 

--- a/Pro/Web-UI/Health.md
+++ b/Pro/Web-UI/Health.md
@@ -2,6 +2,19 @@ The health views of the Web UI display the current status of all the running Kar
 
 ![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-health.png)
 
+## Static Membership Identification
+
+When using Kafka's static membership feature (`group.instance.id`), the Web UI displays the static membership ID for each subscription group in consumer reports. This identifier appears in both the subscription views and the Health Overview, making it easier to identify specific consumer instances.
+
+Static membership IDs are particularly useful for:
+
+- **Identifying specific consumers**: Quickly locate a particular consumer instance across restarts
+- **Debugging rebalance issues**: Understand which consumers are involved in rebalance events
+- **Deployment tracking**: Correlate consumer instances with deployment identifiers
+- **Operational monitoring**: Track consumer instances that maintain stable group membership
+
+When a consumer is configured with a `group.instance.id`, this value is displayed alongside other subscription information. For consumers without static membership configured, this field will not appear.
+
 ## LSO Freezes Awareness
 
 In the world of Kafka, the Last Stable Offset (LSO) is pivotal in ensuring message integrity and order, especially for idempotent producers. However, at times, the LSO may hang, affecting the consumption of messages and potentially bringing to a standstill any consumers operating at a `read_committed` isolation level. This documentation will shed light on the concept, the problems it may cause, and how the Karafka Web UI can be a lifesaver during such situations.

--- a/Pro/Web-UI/Topics-Insights.md
+++ b/Pro/Web-UI/Topics-Insights.md
@@ -27,6 +27,16 @@ The Replication tab provides insights into the replication dynamics of each topi
 
 This tab is essential for monitoring the health and integrity of topic replication. It helps users identify potential issues like under-replicated partitions or uneven distribution of leader roles.
 
+### Fault Tolerance Indicators
+
+The Replication tab displays `min.insync.replicas` alongside the replication factor for each topic, providing a complete picture of your topic's durability configuration. Based on these values, the Web UI shows fault tolerance warnings to help you identify potential risks:
+
+- **No redundancy**: When replication factor is 1, there is no data redundancy—if the broker fails, data may be lost
+- **Zero fault tolerance**: When `min.insync.replicas` equals the replication factor, no broker failures can be tolerated while maintaining write availability
+- **Low durability**: When the configuration provides minimal fault tolerance that may not be suitable for production workloads
+
+These warnings help you proactively identify topics that may need configuration adjustments to meet your durability and availability requirements.
+
 <p align="center">
   <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-replication.png" />
 </p>


### PR DESCRIPTION
## Summary

- Document topic-level pause/resume functionality for pausing all partitions of a topic at once across all consumer processes via Health Overview
- Add static membership identification section documenting `group.instance.id` display in subscription views and Health Overview
- Document fault tolerance indicators in Topics Insights showing `min.insync.replicas` with replication factor and durability warnings
- Add commands topic validation alert warning when `karafka_consumers_commands` topic is missing

## Test plan

- [x] Markdown linting passes (`npm run lint`)
- [x] Full documentation validation passes (`./bin/mklint`)