### PR TITLE
docs: add FAQ and usage example for multi-cluster producer

### DIFF
--- a/Advanced/Multi-Cluster-Setup.md
+++ b/Advanced/Multi-Cluster-Setup.md
@@ -79,6 +79,22 @@ SECONDARY_CLUSTER_PRODUCER = WaterDrop::Producer.new do |config|
 end
 ```
 
+Once configured, use the secondary producer directly to send messages to that cluster:
+
+```ruby
+# Produce asynchronously to the secondary cluster
+SECONDARY_CLUSTER_PRODUCER.produce_async(
+  topic: 'events',
+  payload: { event: 'user_created' }.to_json
+)
+
+# Or produce synchronously
+SECONDARY_CLUSTER_PRODUCER.produce_sync(
+  topic: 'events',
+  payload: { event: 'user_created' }.to_json
+)
+```
+
 ## Common Mistakes
 
 - **Ignoring Primary Default**: Forgetting that `Karafka.producer` and ActiveJob jobs default to the primary cluster can lead to unexpected routing of messages.

--- a/FAQ.md
+++ b/FAQ.md
@@ -220,6 +220,7 @@
 1. [What are poison pill messages, and how should I handle them in Karafka?](#what-are-poison-pill-messages-and-how-should-i-handle-them-in-karafka)
 1. [How can I validate messages before processing them?](#how-can-i-validate-messages-before-processing-them)
 1. [How should I handle missing or invalid records during message processing?](#how-should-i-handle-missing-or-invalid-records-during-message-processing)
+1. [How do I produce messages to a secondary Kafka cluster?](#how-do-i-produce-messages-to-a-secondary-kafka-cluster)
 
 ---
 
@@ -3220,3 +3221,32 @@ end
 ```
 
 For comprehensive error handling strategies, see [Error Handling and Back-Off Policy](Operations-Error-Handling-and-Back-Off-Policy).
+
+## How do I produce messages to a secondary Kafka cluster?
+
+When working with multiple Kafka clusters, `Karafka.producer` always targets the primary cluster. To produce messages to a secondary cluster, create a dedicated WaterDrop producer instance configured for that cluster and use it directly:
+
+```ruby
+# Create a producer for the secondary cluster (typically in an initializer)
+SECONDARY_CLUSTER_PRODUCER = WaterDrop::Producer.new do |config|
+  config.deliver = true
+  config.kafka = {
+    'bootstrap.servers': 'secondary-cluster.example.com:9092',
+    'request.required.acks': 1
+  }
+end
+
+# Use it to produce messages
+SECONDARY_CLUSTER_PRODUCER.produce_async(
+  topic: 'events',
+  payload: { event: 'user_created' }.to_json
+)
+
+# Or synchronously
+SECONDARY_CLUSTER_PRODUCER.produce_sync(
+  topic: 'events',
+  payload: { event: 'user_created' }.to_json
+)
+```
+
+For detailed configuration and considerations when working with multiple clusters, see the [Multi-Cluster Setup](Multi-Cluster-Setup) documentation.


### PR DESCRIPTION
## Summary

- Add FAQ entry explaining how to produce messages to a secondary Kafka cluster
- Update Multi-Cluster-Setup documentation with usage example showing `produce_async` and `produce_sync`

The existing multi-cluster doc showed how to create a secondary producer but not how to use it, which was a common source of confusion.

## Test plan

- [x] `npm run lint` passes
- [x] `./bin/mklint` passes