### PR TITLE
docs: add fiber blocking warning to statistics.emitted handlers

### DIFF
--- a/Operations/Monitoring-and-Logging.md
+++ b/Operations/Monitoring-and-Logging.md
@@ -210,6 +210,8 @@ Karafka.monitor.notifications_bus.register_event('app.external_api_call')
 
     When subscribing to `statistics.emitted`, ensure your code is concise and non-blocking, as this runs every 5 seconds and during active processing. Long-running handlers can impede the polling process, affecting message consumption. Rigorously test your handlers - failures in processing these statistics can lead to critical exceptions that disrupt your consumption process.
 
+    Operations in statistics event handlers must be fast and non-blocking. In some rdkafka configurations, fibers are used instead of threads for event delivery. This means that a slow or blocking statistics handler will prevent subsequent events from other producers/consumers from being processed, causing delays across your entire application.
+
 !!! note
 
     Karafka emits metrics every 5 seconds by default, governed by the Kafka setting `statistics.interval.ms`. Metrics are also published during processing and long polling. Whether you are processing data or waiting on more information being shipped from Kafka, metrics publishing will occur.

--- a/WaterDrop/Monitoring-and-Logging.md
+++ b/WaterDrop/Monitoring-and-Logging.md
@@ -139,6 +139,12 @@ producer.produce_sync(topic: 'my.topic', payload: 'my.message')
 
 ## Usage Statistics
 
+!!! warning "Always keep `statistics.emitted` handlers concise and non-blocking"
+
+    When subscribing to `statistics.emitted`, ensure your code is concise and non-blocking. Long-running handlers can impede the message production process and overall producer performance. Rigorously test your handlers - failures in processing these statistics can lead to critical exceptions that disrupt your production process.
+
+    Operations in statistics event handlers must be fast and non-blocking. In some rdkafka configurations, fibers are used instead of threads for event delivery. This means that a slow or blocking statistics handler will prevent subsequent events from other producers/consumers from being processed, causing delays across your entire application.
+
 WaterDrop is configured to emit internal `librdkafka` metrics every five seconds. You can change this by setting the `kafka` `statistics.interval.ms` configuration property to a value greater than of equal `0`. Emitted statistics are available after subscribing to the `statistics.emitted` publisher event. If set to `0`, metrics will not be published.
 
 The statistics include all of the metrics from `librdkafka` (complete list [here](Librdkafka-Statistics)) as well as the diff of those against the previously emitted values.


### PR DESCRIPTION
## Summary

- Adds warning about fiber-based event delivery in rdkafka configurations to both Karafka and WaterDrop documentation
- Clarifies that statistics event handlers must be fast and non-blocking
- Explains that slow handlers can block subsequent events from other producers/consumers when fibers are used instead of threads

## Changes

- **Operations/Monitoring-and-Logging.md**: Enhanced existing warning with fiber blocking details
- **WaterDrop/Monitoring-and-Logging.md**: Added new warning section to Usage Statistics

## Test plan

- [x] Ran `npm run lint` - no errors
- [x] Verified markdown formatting is correct
- [x] Checked that admonition blocks are properly formatted