### PR TITLE
docs: add Pro license server incident (Feb 11, 2026)

### DIFF
--- a/Status.md
+++ b/Status.md
@@ -10,6 +10,24 @@
 
 ## Incident History
 
+!!! success "[RESOLVED] February 11, 2026 - Pro License Server Hardware Failure"
+
+    **Status:** Fully Resolved
+    **Impact:** Moderate
+    **Affected:** Karafka Pro users attempting to access the license server during the incident window
+
+    A hardware failure on a network switch at Hetzner's infrastructure caused a temporary outage of the Karafka Pro license server. The incident began at approximately 2:47 PM CET and was fully resolved by 3:12 PM CET, resulting in approximately 25 minutes of downtime.
+
+    **Incident Timeline (CET):**
+    - 2:47 PM - Initial detection of Hetzner infrastructure issues
+    - 2:51 PM - Migration process initiated
+    - 3:09 PM - Backup server deployment started
+    - 3:12 PM - Service fully restored
+
+    **Response:** The automated disaster recovery system successfully performed server rotation, though the 15-minute threshold before activation meant some users experienced service interruption. Users requiring immediate access during the incident were offered offline (embedded) license setup as a workaround.
+
+    **Resolution:** The issue has been fully resolved. A comprehensive postmortem will be published in the upcoming days, detailing the root cause analysis and additional preventive measures to ensure this type of disruption does not affect users in the future.
+
 !!! success "[RESOLVED] August 4, 2025 - OpenSSL 3.0.17 Segmentation Faults"
 
     **Status:** Resolved  


### PR DESCRIPTION
## Summary

Adds incident report to the status page documenting the Pro license server outage on February 11, 2026.

## Details

- Hardware failure on Hetzner network switch caused 25-minute outage (2:47 PM - 3:12 PM CET)
- Disaster recovery system successfully performed server rotation
- Issue fully resolved
- Full postmortem to be published with additional preventive measures

## Changes

- Added new incident entry to Status.md incident history