### PR TITLE
docs: update hosting infrastructure information in Pro FAQ

### DIFF
--- a/Pro/FAQ.md
+++ b/Pro/FAQ.md
@@ -262,7 +262,7 @@ We do not hold your credit card information. All subscription management is done
 
 ## Where is the hosting infrastructure located?
 
-Karafka Pro gem license server is located in Hetzner, Germany, Frankfurt. Karafka and Karafka Pro are served directly from [RubyGems](https://rubygems.org).
+Karafka Pro gem license server is hosted on Hetzner in Germany (Frankfurt) with DigitalOcean as a failover provider. The networking layer is managed by Cloudflare. Karafka and Karafka Pro are served directly from [RubyGems](https://rubygems.org).
 
 ## Can I use Karafka Pro with an offline license without using the Karafka gem server?
 


### PR DESCRIPTION
## Summary

Updates the hosting infrastructure information in the Pro FAQ to reflect the current setup:

- Primary hosting: Hetzner (Germany, Frankfurt)
- Failover provider: DigitalOcean
- Networking layer: Managed by Cloudflare

## Changes

- Updated Pro/FAQ.md section "Where is the hosting infrastructure located?" with accurate infrastructure details

## Test plan

- [x] Reviewed the updated FAQ content for accuracy
- [x] Verified markdown formatting is correct