### PR TITLE
docs: update image URLs from cdn.karafka.io to karafka.io

### DIFF
--- a/Advanced/Active-Job.md
+++ b/Advanced/Active-Job.md
@@ -167,7 +167,7 @@ Active Job Karafka adapter will follow the Karafka general [runtime errors handl
 Please keep in mind that **as long as** the error persists, **no** other jobs from a given partition will be processed.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/aj_error_handling.svg" />
+  <img src="https://karafka.io/assets/misc/charts/aj_error_handling.svg" />
 </p>
 
 ## Usage With the Dead Letter Queue

--- a/Advanced/Concurrency-and-Multithreading.md
+++ b/Advanced/Concurrency-and-Multithreading.md
@@ -34,7 +34,7 @@ Karafka uses multiple threads to process messages coming from different topics a
 Using multiple threads for IO intense work can bring great performance improvements to your system "for free."
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/workers-performance.png" />
+  <img src="https://karafka.io/assets/misc/charts/workers-performance.png" />
 </p>
 <p align="center">
   <small>*This example illustrates performance difference for IO intense jobs.</small>
@@ -43,7 +43,7 @@ Using multiple threads for IO intense work can bring great performance improveme
 Example of work distribution amongst two workers:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/processing-workers.svg" />
+  <img src="https://karafka.io/assets/misc/charts/processing-workers.svg" />
 </p>
 
 !!! note
@@ -93,7 +93,7 @@ end
 ```
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/subscription_group_routing.svg" />
+  <img src="https://karafka.io/assets/misc/charts/subscription_group_routing.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates how Karafka routing translates into subscription groups and their underlying connections to Kafka.
@@ -119,7 +119,7 @@ Karafka allows you to parallelize further processing of data from a single parti
 Virtual Partitions allow you to parallelize the processing of data from a single partition. This can drastically increase throughput when IO operations are involved.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/performance.png" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/performance.png" />
 </p>
 <p align="center">
   <small>*This example illustrates the throughput difference for IO intense work, where the IO cost of processing a single message is 1ms.

--- a/Advanced/Dead-Letter-Queue.md
+++ b/Advanced/Dead-Letter-Queue.md
@@ -7,7 +7,7 @@ And this is where the Dead Letter Queue pattern shines.
 A Dead Letter Queue in Karafka is a feature that, when enabled, will transfer problematic messages into a separate topic allowing you to continue processing even upon errors.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/dead_letter_queue/example_flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/dead_letter_queue/example_flow.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates a simple DLQ flow with a processing retry.
@@ -146,7 +146,7 @@ end
 The following diagrams compare DLQ flows in Karafka: the first without the independent flag and the second with it enabled, demonstrating the operational differences between these two settings.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/dead_letter_queue/no_independent.svg" />
+  <img src="https://karafka.io/assets/misc/charts/dead_letter_queue/no_independent.svg" />
 </p>
 <p align="center">
   <small>*The diagram shows DLQ retry behavior without the independent flag: each error in a batch adds to the error counter until the DLQ dispatch takes place on the last erroneous message.
@@ -154,7 +154,7 @@ The following diagrams compare DLQ flows in Karafka: the first without the indep
 </p>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/dead_letter_queue/independent.svg" />
+  <img src="https://karafka.io/assets/misc/charts/dead_letter_queue/independent.svg" />
 </p>
 <p align="center">
   <small>*The diagram shows DLQ retry behavior with the independent flag active: the error counter resets after each message is successfully processed, avoiding DLQ dispatch if all messages recover.

--- a/Advanced/Latency-and-Throughput.md
+++ b/Advanced/Latency-and-Throughput.md
@@ -362,7 +362,7 @@ Tuning consumer configurations in Karafka involves adjusting various settings th
 Below is an example latency impact of enabling `enable.partition.eof` and lowering `fetch.wait.max.ms` to `100`ms, compared to the default values, on a low-traffic topic (1 message per second). In both cases, `max_wait_time` was set to `2000`ms (less is better).
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/latency_and_throughput/consumption_lag_eof.png" />
+  <img src="https://karafka.io/assets/misc/charts/latency_and_throughput/consumption_lag_eof.png" />
 </p>
 <p align="center">
   <small>*Latency in ms on low-volume topic with different configurations (less is better).
@@ -505,7 +505,7 @@ Below, you can find a table summarizing the key aspects of Karafka's parallel pr
 Below is an example latency impact of enabling Virtual Partitions compared to the default values on a partition with 10 messages per second and an IO cost of around 150ms per message. In both cases, the same settings are used.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/latency_and_throughput/no_vps_vs_vps.png" />
+  <img src="https://karafka.io/assets/misc/charts/latency_and_throughput/no_vps_vs_vps.png" />
 </p>
 <p align="center">
   <small>*Latency in ms on a partition with and without Virtual Partitions enabled (same traffic) with around 150ms of IO per message.
@@ -525,7 +525,7 @@ Karafka is designed to prefetch data from Kafka while previously obtained messag
 Under normal operations, when there are no significant lags, Karafka prefetches some data from each assigned topic partition. This is because there is little data ahead to process. For example, if 200 messages are available for processing from 10 partitions, Karafka might prefetch these messages in small batches, resulting in 10 independent jobs with 20 messages each.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/latency_and_throughput/regular_work_distribution.svg" />
+  <img src="https://karafka.io/assets/misc/charts/latency_and_throughput/regular_work_distribution.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates the work distribution of prefetched data coming from two partitions.
@@ -539,7 +539,7 @@ The situation changes when Karafka experiences data spikes or when a significant
 This behavior is driven by the need to process data quickly. Still, it can lead to reduced parallelism when large batches from a single partition dominate the internal buffer.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/latency_and_throughput/non_distributed_work.svg" />
+  <img src="https://karafka.io/assets/misc/charts/latency_and_throughput/non_distributed_work.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates the lack of work distribution of prefetched data when batch comes from a single partition.

--- a/Advanced/Pausing-Seeking-and-Rate-Limiting.md
+++ b/Advanced/Pausing-Seeking-and-Rate-Limiting.md
@@ -264,7 +264,7 @@ The challenge arises here: If you use the `#pause` or `#seek` method frequently 
 It's crucial to be aware, especially if you're using a third-party Kafka provider that charges based on the number of messages sent, that frequent pausing and resuming can inflate costs. This is due to the aforementioned frequent prefetching of the same data, which can result in the same messages being counted multiple times for billing purposes. Always ensure alignment and configuration are optimized to prevent unnecessary financial implications.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/seek-impact.png" alt="karafka seek misuse impact" />
+  <img src="https://karafka.io/assets/misc/printscreens/seek-impact.png" alt="karafka seek misuse impact" />
 </p>
 <p align="center">
   <small>

--- a/Advanced/Swarm-Multi-Process.md
+++ b/Advanced/Swarm-Multi-Process.md
@@ -9,7 +9,7 @@ Karafka's Swarm Mode allows for the efficient CPU-intensive processing of Kafka 
 Karafka's Swarm Mode is based on the "Supervisor-Worker" architectural pattern. It utilizes a controller process for supervision and multiple independent child processes for parallel execution. This setup enhances Kafka message processing for CPU-intensive tasks by leveraging multi-process execution. Each child process periodically reports its status to the supervisory master, ensuring system health and efficiency.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/swarm/architecture.svg" />
+  <img src="https://karafka.io/assets/misc/charts/swarm/architecture.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates the relationship between the supervisor and the nodes.
@@ -194,7 +194,7 @@ Following a node's shutdown - graceful or forceful - Karafka imposes a mandatory
 Karafka's Swarm Mode ensures robust process management through these meticulous supervision strategies, promoting system stability and resilience.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/swarm/supervisor-flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/swarm/supervisor-flow.svg" />
 </p>
 <p align="center">
   <small>*Diagram illustrating flow of supervision of a swarm node.
@@ -280,7 +280,7 @@ By carefully preparing for and executing the warmup phase, you ensure your Karaf
 Below, you can compare memory usage when running 3 independent processes versus Swarm with 3 nodes and a supervisor. In this case, Swarm uses around 50% less memory than independent processes.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/swarm/shared-memory.png" alt="Karafka Swarm mode vs. Shared Memory"/>
+  <img src="https://karafka.io/assets/misc/charts/swarm/shared-memory.png" alt="Karafka Swarm mode vs. Shared Memory"/>
 </p>
 <p align="center">
   <small>*Diagram illustrating memory usage with and without Swarm with the same number of consumers. Less is better.
@@ -463,7 +463,7 @@ If, after the `shutdown_timeout` period, any nodes have not shut down (indicatin
 This forceful termination step is crucial for preventing resource leaks and ensuring the system remains clean and ready for a potential restart or to end operation without impacting the underlying environment.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/swarm/shutdown.svg" />
+  <img src="https://karafka.io/assets/misc/charts/swarm/shutdown.svg" />
 </p>
 <p align="center">
   <small>*Diagram illustrating the shutdown flow and interactions between supervisor and child nodes.
@@ -478,7 +478,7 @@ In Swarm Mode, the Web UI distinguishes each node as a separate process. However
 
 Due to librdkafka's fork-safety limitations, the supervisor process does not appear directly in the Web UI because it cannot hold open connections to Kafka. However, The supervisor's presence is inferred through the PPID label of swarm nodes. Since all nodes share the same supervisor PID as their PPID, you can indirectly identify the supervisor process that way.
 
-<img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/swarm-ppids.png" alt="karafka web dashboard view ppids" />
+<img src="https://karafka.io/assets/misc/printscreens/web-ui/swarm-ppids.png" alt="karafka web dashboard view ppids" />
 
 ## Swarm vs. Multi-Threading and Virtual Partitions
 

--- a/Build-vs-Buy.md
+++ b/Build-vs-Buy.md
@@ -14,7 +14,7 @@ A senior developer is typically $10,000/mo. One with Kafka knowledge even more. 
 Baremetrics has a [Build vs. Buy calculator](https://baremetrics.com/build-vs-buy).  Here are some **extremely** optimistic projections, now let the numbers speak for themselves:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/build-vs-buy.png" />
+  <img src="https://karafka.io/assets/misc/printscreens/build-vs-buy.png" />
 </p>
 
 ## Features

--- a/Components.md
+++ b/Components.md
@@ -49,7 +49,7 @@ Karafka Web UI is a user interface for the [Karafka framework](https://github.co
 The following image provides a visual preview of the Karafka Web UI interface, showcasing its dashboard for monitoring Kafka consumers, producers, and topics in a centralized view:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui.png" alt="Karafka Web UI"/>
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui.png" alt="Karafka Web UI"/>
 </p>
 
 ## Karafka-Rdkafka

--- a/Development/Gems-Publishing.md
+++ b/Development/Gems-Publishing.md
@@ -59,7 +59,7 @@ The trusted publishing configuration is already set up in the Karafka GitHub env
 
     <p align="center">
       <img
-        src="https://cdn.karafka.io/assets/misc/printscreens/development/gems-publishing/releases.png"
+        src="https://karafka.io/assets/misc/printscreens/development/gems-publishing/releases.png"
         style="border: 1px solid #ddd; border-radius: 2px; padding: 10px;"
       />
     </p>
@@ -79,7 +79,7 @@ The trusted publishing configuration is already set up in the Karafka GitHub env
 
     <p align="center">
       <img
-        src="https://cdn.karafka.io/assets/misc/printscreens/development/gems-publishing/releasing.png"
+        src="https://karafka.io/assets/misc/printscreens/development/gems-publishing/releasing.png"
         style="border: 1px solid #ddd; border-radius: 2px; padding: 10px;"
       />
     </p>
@@ -94,7 +94,7 @@ After publishing the GitHub release, the push workflow will be triggered and req
 
     <p align="center">
       <img
-        src="https://cdn.karafka.io/assets/misc/printscreens/development/gems-publishing/workflows.png"
+        src="https://karafka.io/assets/misc/printscreens/development/gems-publishing/workflows.png"
         style="border: 1px solid #ddd; border-radius: 2px; padding: 10px;"
       />
     </p>
@@ -109,7 +109,7 @@ After publishing the GitHub release, the push workflow will be triggered and req
 
     <p align="center">
       <img
-        src="https://cdn.karafka.io/assets/misc/printscreens/development/gems-publishing/approval.png"
+        src="https://karafka.io/assets/misc/printscreens/development/gems-publishing/approval.png"
         style="border: 1px solid #ddd; border-radius: 2px; padding: 10px;"
       />
     </p>
@@ -121,7 +121,7 @@ After publishing the GitHub release, the push workflow will be triggered and req
 
     <p align="center">
       <img
-        src="https://cdn.karafka.io/assets/misc/printscreens/development/gems-publishing/logs.png"
+        src="https://karafka.io/assets/misc/printscreens/development/gems-publishing/logs.png"
         style="border: 1px solid #ddd; border-radius: 2px; padding: 10px;"
       />
     </p>

--- a/FAQ.md
+++ b/FAQ.md
@@ -2048,7 +2048,7 @@ Remember to make sure that the timeout value you set is suitable for your use ca
 In this case, the high number you see is in microseconds, not milliseconds. To put it into perspective, 1 millisecond is 1,000 microseconds. So, if you see a metric like 15k, it's just 0.015 of a second. Always ensure you're reading the metrics with the correct scale in mind. 
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/karafka_dd_producer_latency_metric.png" alt="producer network latency chart for waterdrop" />
+  <img src="https://karafka.io/assets/misc/printscreens/karafka_dd_producer_latency_metric.png" alt="producer network latency chart for waterdrop" />
 </p>
 
 ## What is the purpose of the `karafka_consumers_reports` topic?

--- a/Operations/Deployment.md
+++ b/Operations/Deployment.md
@@ -117,17 +117,17 @@ Please follow the below instructions for both cluster initialization and Karafka
 1. Select `Custom create` and `Provisioned` settings.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/creation_method.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/creation_method.png" />
     </p>
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/provisioned2.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/provisioned2.png" />
     </p>
 
 1. Use custom config and set `auto.create.topics.enable` to `true` unless you want to create topics using Kafka API. You can change it later, and in general, it is recommended to disallow auto-topic creation (typos, etc.), but this can be useful for debugging.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/broker-settings.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/broker-settings.png" />
     </p>
 
 1. Setup your VPC and networking details.
@@ -136,20 +136,20 @@ Please follow the below instructions for both cluster initialization and Karafka
 1. **Enable** `SASL/SCRAM authentication`
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/access-methods.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/access-methods.png" />
     </p>
 
 1. Provision your cluster.
 1. Make sure your cluster is accessible from your machines. You can test it by using the AWS VPC Reachability Analyzer.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/reachability.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/reachability.png" />
     </p>
 
 1. Visit your cluster `Properties` page and copy the `Endpoints` addresses.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/brokers-list.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/brokers-list.png" />
     </p>
 
 1. Log in to any of your machines and run a `telnet` session to any of the brokers:
@@ -168,19 +168,19 @@ Please follow the below instructions for both cluster initialization and Karafka
 1. Go to the AWS Secret Manager and create a key starting with `AmazonMSK_` prefix. Select `Other type of secret` and `Plaintext` and provide the following value inside of the text field:
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/secret_type2.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/secret_type2.png" />
     </p>
 
 1. In the `Encryption key` section, press the `Add new key`.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/add_new_key.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/add_new_key.png" />
     </p>
 
 1. Create a `Symmetric` key with `Encrypt and decrypt` as a usage pattern.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/keys.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/keys.png" />
     </p>
 
 1. Select your key in the `Encryption key` section and press `Next`.
@@ -190,13 +190,13 @@ Please follow the below instructions for both cluster initialization and Karafka
 1. Navigate to the `Associated secrets from AWS Secrets Manager` section and press `Associate secrets`
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/associate_secrets.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/associate_secrets.png" />
     </p>
 
 1. Press the `Choose secrets` and select the previously created secret.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/msk/associate_secrets2.png" />
+      <img src="https://karafka.io/assets/misc/instructions/msk/associate_secrets2.png" />
     </p>
 
 1. Press `Associate secrets`. It will take AWS a while to do it.
@@ -256,7 +256,7 @@ Please make sure that your instances can reach Kafka. Keep in mind that security
 Please make sure your custom setting `default.replication.factor` value matches what you have declared as `Number of zones` in the `Brokers` section:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/instructions/msk/brokers_count.png" />
+  <img src="https://karafka.io/assets/misc/instructions/msk/brokers_count.png" />
 </p>
 
 ### Rdkafka::RdkafkaError: Broker: Topic authorization failed (topic_authorization_failed)
@@ -299,7 +299,7 @@ You can also use this ACL command to give all operations access for the brokers 
 Karafka works with the Heroku Kafka add-on, but it requires some extra configuration and understanding of how the Heroku Kafka add-on works.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/instructions/heroku/dyno.png" />
+  <img src="https://karafka.io/assets/misc/instructions/heroku/dyno.png" />
 </p>
 
 Details about how Kafka for Heroku works can also be found here:
@@ -790,13 +790,13 @@ Deploying Karafka on Confluent Cloud offers a streamlined way to manage  Kafka i
     - Once your cluster is active, go to the 'Topics' tab and create the necessary topics that your application will use.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/confluent/topics-select.png" />
+      <img src="https://karafka.io/assets/misc/instructions/confluent/topics-select.png" />
     </p>
 
     - Set appropriate partitions and retention policies based on your expected workload and data retention needs.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/instructions/confluent/topics-new.png" />
+      <img src="https://karafka.io/assets/misc/instructions/confluent/topics-new.png" />
     </p>
 
 1. **Configure Web UI Topics**

--- a/Operations/Error-Handling-and-Back-Off-Policy.md
+++ b/Operations/Error-Handling-and-Back-Off-Policy.md
@@ -198,7 +198,7 @@ A monitoring and logging layer is strongly recommended to ensure prompt notifica
 Karafka keeps track of the last committed offset alongside Kafka when you mark a message as consumed. This means that after the pause, Karafka will start back from the failed message, not from the first message from the batch. This approach severely reduces the number of messages that must be reprocessed upon errors.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/on_errors_behaviour.svg" />
+  <img src="https://karafka.io/assets/misc/charts/on_errors_behaviour.svg" />
 </p>
 
 !!! note

--- a/Operations/Monitoring-and-Logging.md
+++ b/Operations/Monitoring-and-Logging.md
@@ -283,7 +283,7 @@ end
 Karafka Web UI is a user interface for the [Karafka framework](https://github.com/karafka/karafka). The Web UI provides a convenient way for developers to monitor and manage their Karafka-based applications, without the need to use the command line or third party software. It does **not** require any additional database beyond Kafka itself.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui.png" alt="Karafka Web UI"/>
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui.png" alt="Karafka Web UI"/>
 </p>
 
 You can read more about its features [here](Web-UI-Features), and the installation documentation can be found [here](Web-UI-Getting-Started).
@@ -295,7 +295,7 @@ You can read more about its features [here](Web-UI-Features), and the installati
 
 Karafka's integration with [AppSignal](https://www.appsignal.com/) offers comprehensive support for error reporting and performance monitoring, making it a seamless solution for monitoring your Kafka-based applications.
 
-![Example Karafka AppSignal dashboard](https://cdn.karafka.io/assets/misc/printscreens/karafka_appsignal_dashboard_example.png)
+![Example Karafka AppSignal dashboard](https://karafka.io/assets/misc/printscreens/karafka_appsignal_dashboard_example.png)
 
 The Karafka AppSignal integration provides an extensive set of metrics with both per-topic and per-partition resolution. This granularity allows you to drill down into specific aspects of your Kafka processing pipeline.
 
@@ -340,7 +340,7 @@ Karafka.producer.monitor.subscribe(appsignal_errors_listener)
 # setup the metrics listener here if you want
 ```
 
-![Example Karafka AppSignal Errors dashboard](https://cdn.karafka.io/assets/misc/printscreens/karafka_appsignal_dashboard_errors_example.png)
+![Example Karafka AppSignal Errors dashboard](https://karafka.io/assets/misc/printscreens/karafka_appsignal_dashboard_errors_example.png)
 
 ### Metrics Instrumentation
 
@@ -421,7 +421,7 @@ Karafka.monitor.subscribe(dd_listener)
 
 You can also find [here](https://github.com/karafka/karafka/blob/master/lib/karafka/instrumentation/vendors/datadog/dashboard.json) a ready-to-import Datadog dashboard configuration file that you can use to monitor your consumers.
 
-![Example Karafka DD dashboard](https://cdn.karafka.io/assets/misc/printscreens/karafka_dd_dashboard_example.png)
+![Example Karafka DD dashboard](https://karafka.io/assets/misc/printscreens/karafka_dd_dashboard_example.png)
 
 #### Extending Datadog Metrics with Custom Tags
 
@@ -595,7 +595,7 @@ end
 Karafka.monitor.subscribe(dd_logger_listener) if %w[staging production].include?(Rails.env)
 ```
 
-![Example Karafka DD dashboard](https://cdn.karafka.io/assets/misc/printscreens/karafka_dd_tracing.png)
+![Example Karafka DD dashboard](https://karafka.io/assets/misc/printscreens/karafka_dd_tracing.png)
 
 !!! note
 

--- a/Pro/Adaptive-Iterator.md
+++ b/Pro/Adaptive-Iterator.md
@@ -15,7 +15,7 @@ Do not use the Adaptive Iterator if:
 - Your consumer requires strict control over offset management outside the default provided by the Adaptive Iterator.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/adaptive_iterator/flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/adaptive_iterator/flow.svg" />
 </p>
 <p align="center">
   <small>*Illustration presenting how Adaptive Iterator work.

--- a/Pro/Cleaner-API.md
+++ b/Pro/Cleaner-API.md
@@ -9,7 +9,7 @@ Remarkably, this memory clearance occurs before the entire batch is processed, e
 The below example illustrates how the Cleaner API releases both `payload` and `raw_payload` after each of the processed messages.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/flow.svg" />
 </p>
 
 !!! note "Cleaner API and Kafka Message Immutability"
@@ -127,11 +127,11 @@ Each fetched batch contained at most 500 messages.
 ### Message size of 1MB
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/1mb_memory.png" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/1mb_memory.png" />
 </p>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/1mb_stdev.png" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/1mb_stdev.png" />
 </p>
 
 **Conclusion**: For messages approximately 1MB in size, the Cleaner API proves invaluable. It drastically cuts memory usage and stabilizes memory consumption patterns, reducing fluctuations and ensuring smoother, more efficient operations.
@@ -139,11 +139,11 @@ Each fetched batch contained at most 500 messages.
 ### Message size of 100KB
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/100kb_memory.png" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/100kb_memory.png" />
 </p>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/100kb_stdev.png" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/100kb_stdev.png" />
 </p>
 
 **Conclusion**: For messages around 100KB in size, the Cleaner API still demonstrates a notable impact. While the memory savings might not be as dramatic as with 1MB messages, the reduction in memory usage and stabilization of consumption patterns remain significant, underscoring the API's effectiveness also at this size.
@@ -151,11 +151,11 @@ Each fetched batch contained at most 500 messages.
 ### Message size of 10KB
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/10kb_memory.png" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/10kb_memory.png" />
 </p>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/10kb_stdev.png" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/10kb_stdev.png" />
 </p>
 
 **Conclusion**: When processing messages of approximately 10KB, the Cleaner API's influence is more nuanced. The memory savings hover around 4-5%, which might seem modest compared to larger payloads. However, the standout benefit lies in the considerable reduction in standard deviation. This reduction means memory usage is more predictable, leading to improved and more consistent operational performance.
@@ -163,11 +163,11 @@ Each fetched batch contained at most 500 messages.
 ### Message size of 1KB
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/1kb_memory.png" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/1kb_memory.png" />
 </p>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/cleaner_api/1kb_stdev.png" />
+  <img src="https://karafka.io/assets/misc/charts/cleaner_api/1kb_stdev.png" />
 </p>
 
 **Conclusion**: For messages approximating 1KB in size, the impact of employing the Cleaner API is virtually nonexistent. Its application doesn't notably affect the memory usage metrics for such small messages. However, it's worth noting that even if most messages are of this size, there could be occasional or periodic inflows of larger payloads. In such scenarios, the Cleaner API can help manage these sporadic spikes in memory usage. Therefore, even with predominantly 1KB messages, integrating the Cleaner API can be a prudent strategy if there's an anticipation of intermittently receiving messages with increased payloads.

--- a/Pro/Delayed-Topics.md
+++ b/Pro/Delayed-Topics.md
@@ -7,7 +7,7 @@ Delay is implemented by pausing the consumption of the partitions for a specifie
 This makes the Delayed Topic feature a great choice for applications that need to delay the processing of specific messages without impacting the processing of other messages in the system. By using Karafka's built-in partition pausing mechanism, delayed messages can be processed in a way that is both efficient and reliable.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/delayed_topics/flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/delayed_topics/flow.svg" />
 </p>
 <p align="center">
   <small>*Illustration presenting how Delayed Topics delays too young messages.
@@ -45,7 +45,7 @@ Using `#sleep` inside consumers is **not** recommended. Sleep can heavily impact
 Using `#sleep` on one of the partitions:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/delayed_topics/sleep-lag.png" />
+  <img src="https://karafka.io/assets/misc/charts/delayed_topics/sleep-lag.png" />
 </p>
 <p align="center">
   <small>*Sleep can affect other topics and partitions running in parallel in other threads.
@@ -55,7 +55,7 @@ Using `#sleep` on one of the partitions:
 vs. delaying via the `#delay_by` API:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/delayed_topics/pause-lag.png" />
+  <img src="https://karafka.io/assets/misc/charts/delayed_topics/pause-lag.png" />
 </p>
 <p align="center">
   <small><code>#delay_by</code> is affecting only the desired topic/partition while others are processed as fast as possible.
@@ -75,7 +75,7 @@ This limitation also means that messages may be delayed slightly more than the r
 Below is an example distribution of the extra lag beyond the tested and expected ten seconds. In most cases, it is equal to or less than 10% of Karafkas' max wait time.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/delayed_topics/histogram.png" />
+  <img src="https://karafka.io/assets/misc/charts/delayed_topics/histogram.png" />
 </p>
 
 ## Revocation and Shutdown

--- a/Pro/Enhanced-Active-Job.md
+++ b/Pro/Enhanced-Active-Job.md
@@ -39,7 +39,7 @@ The above code will ensure that jobs related to the same user will always be dis
 We recommend using the `:key` as then it can be used for combining Enhanced Active Job with [Virtual Partitions](Pro-Virtual-Partitions).
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/enhanced_aj_ordering.svg" />
+  <img src="https://karafka.io/assets/misc/charts/enhanced_aj_ordering.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates the end distribution of jobs based on the user id.

--- a/Pro/Enhanced-Dead-Letter-Queue.md
+++ b/Pro/Enhanced-Dead-Letter-Queue.md
@@ -82,7 +82,7 @@ When that happens, Karafka will retry two times and continue processing despite 
 Enhanced Dead Letter Queue ensures that messages moved to the DLQ topic will always reach the same partition and in order, even when the DLQ topic has a different number of partitions. This means that you can implement pipelines for processing broken messages and rely on the ordering warranties from the original topic.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/enhanced_dlq_flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/enhanced_dlq_flow.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates how Enhanced DLQ preserves order of messages from different partitions.

--- a/Pro/Expiring-Messages.md
+++ b/Pro/Expiring-Messages.md
@@ -9,7 +9,7 @@ Karafka's Expiring Messages filtering process takes place before the virtual par
 By filtering messages before they are partitioned and dispatched, Karafka reduces the number of messages that need to be processed by each consumer. This approach ensures that only relevant and recent messages are dispatched to consumers, making it easier for them to process the data and reducing the overall processing load on the system. This optimization helps in improving the performance of the overall system and enables more efficient data processing.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/expiring_messages_flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/expiring_messages_flow.svg" />
 </p>
 <p align="center">
   <small>*Illustration presenting how Expiring Messages filter out too old messages.

--- a/Pro/Filtering-API.md
+++ b/Pro/Filtering-API.md
@@ -53,7 +53,7 @@ If you are looking for more extensive examples, you can check out the implementa
 Filter instance is created when Karafka encounters a given topic partition for the first time and is long-lived. While their primary responsibility is to filter the incoming data, they can also alter the flow behavior. Hence it is essential to remember that part of their operations happens **after** all the data is being processed at the moment of post-execution strategy application. This means that there may be a significant delay between the filtering and the invocation of `#action` that is equal to the collective processing time of all the data of a given topic partition.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/filtering_api_action_application.svg" />
+  <img src="https://karafka.io/assets/misc/charts/filtering_api_action_application.svg" />
 </p>
 <p align="center">
   <small>*Lifecycle of filters, illustrating their post-processing usage for action altering.

--- a/Pro/HIPAA-PHI-PII-Support.md
+++ b/Pro/HIPAA-PHI-PII-Support.md
@@ -84,7 +84,7 @@ One of the core privacy principles under HIPAA and other privacy regulations is 
 You can learn more about the Partial Payload Sanitization [here](Pro-Web-UI-Policies#partial-payload-sanitization).
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/explorer_sanitization.png" alt="karafka web displayed data sanitization" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/explorer_sanitization.png" alt="karafka web displayed data sanitization" />
 </p>
 
 ### 4. Logging and Auditing

--- a/Pro/Long-Running-Jobs.md
+++ b/Pro/Long-Running-Jobs.md
@@ -12,7 +12,7 @@ Maximum poll interval (300000ms) exceeded by 255ms
 This value is effectively the **maximum** time you can spend processing messages fetched in a single `poll` even if they come from different partitions. Once this is exceeded, the given process will be removed from the group. This can cause the group to become unstable due to frequent rebalances.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/long_running_jobs/standard.svg" />
+  <img src="https://karafka.io/assets/misc/charts/long_running_jobs/standard.svg" />
 </p>
 <p align="center">
   <small>*Standard processing flow requires all the data to be processed before polling another batch of messages.
@@ -34,7 +34,7 @@ Long-Running Jobs feature follows the [Confluent recommended strategy](https://w
 That way, as long as no rebalances occur during the processing that would cause the partition to be revoked from the given process, polling can happen within the boundaries of `max.poll.interval.ms`.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/long_running_jobs/flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/long_running_jobs/flow.svg" />
 </p>
 <p align="center">
   <small>*With Long-Running Job enabled, the given partition is paused for the processing time, and polling happens independently from processing.

--- a/Pro/Multiplexing.md
+++ b/Pro/Multiplexing.md
@@ -19,7 +19,7 @@ Multiplexing enables more effective data handling and improves performance by di
 Multiplexing increases throughput and significantly enhances processing capabilities in scenarios with multi-partition lags. When a single process subscribes to multiple partitions, it can swiftly address lags in any of them, ensuring more consistent performance across your system. This advantage becomes particularly prominent in IO-intensive workloads where efficient data handling and processing are crucial.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/multiplexing/500k_lag.png" />
+  <img src="https://karafka.io/assets/misc/charts/multiplexing/500k_lag.png" />
 </p>
 <p align="center">
   <small>*This example illustrates the performance difference for IO intense work, where the IO cost of processing a single message is 1ms and a total lag of 500 000 messages in five partitions.
@@ -265,7 +265,7 @@ Here's a breakdown of how it operates when the dynamic mode is enabled:
 Dynamic Multiplexing in Karafka is about smartly adapting to the system's needs. It scales down to conserve resources when the load is low but remains ready to scale up as soon as the demand increases. This balance ensures that resources are used efficiently without compromising the system's ability to handle incoming data effectively. 
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/multiplexing/flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/multiplexing/flow.svg" />
 </p>
 <p align="center">
   <small>*This diagram illustrates the upscaling and downscaling flow for dynamic multiplexing. 

--- a/Pro/Parallel-Segments.md
+++ b/Pro/Parallel-Segments.md
@@ -13,7 +13,7 @@ The key difference from Virtual Partitions is that each consumer group in the Pa
 Below is a diagram illustrating an example partitioning flow of a single partition of data. Work will be distributed among three parallel segment consumer groups.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/parallel_segments/partitioning.svg" />
+  <img src="https://karafka.io/assets/misc/charts/parallel_segments/partitioning.svg" />
 </p>
 
 ## When to Use Parallel Segments

--- a/Pro/Recurring-Tasks.md
+++ b/Pro/Recurring-Tasks.md
@@ -341,7 +341,7 @@ The Karafka Web UI provides comprehensive tools for managing and monitoring recu
 
 - **Execution Logs**: The Web UI enables you to explore the logs of task executions, offering insights into when tasks were executed, their outcomes, and whether any issues occurred.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/recurring-tasks.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/recurring-tasks.png)
 
 ## Error Handling and Retries
 

--- a/Pro/Rotating-Credentials.md
+++ b/Pro/Rotating-Credentials.md
@@ -5,7 +5,7 @@ To do so:
 1. Go to your license credentials page.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/gems_license_page.png" />
+      <img src="https://karafka.io/assets/misc/printscreens/gems_license_page.png" />
     </p>
 
 1. Press the "Rotate credentials" button.
@@ -13,7 +13,7 @@ To do so:
 1. Read the disclaimers.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/gems_rotate_page.png" />
+      <img src="https://karafka.io/assets/misc/printscreens/gems_rotate_page.png" />
     </p>
 
 1. Press the "I understand. Send me an email with the rotation link." button.

--- a/Pro/Routing-Patterns.md
+++ b/Pro/Routing-Patterns.md
@@ -9,7 +9,7 @@ When you define a route using a regexp pattern, Karafka monitors the Kafka topic
 Below, you can find a conceptual diagram of how the discovery process works:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/routing_patterns/detection_flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/routing_patterns/detection_flow.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates how the detection process works. When Karafka detects new topics in Kafka, it will try to match them, expand routes, and process incoming data.
@@ -41,7 +41,7 @@ Subsequently, this newly registered topic is created as the `:discovered` type. 
 Diagram below represents the relationship between topics of various types and how they operate within Karafka routing:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/routing_patterns/routes.svg" />
+  <img src="https://karafka.io/assets/misc/charts/routing_patterns/routes.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates how a single consumer group and subscription group can incorporate multiple topics of various types. All `:discovered` topics always use the same settings as their base `:matcher` topic.

--- a/Pro/Scheduled-Messages.md
+++ b/Pro/Scheduled-Messages.md
@@ -11,7 +11,7 @@ Each day at midnight, Karafka's scheduler, a dedicated consumer, reloads and sca
 One key aspect of Karafka's handling of scheduled messages is its treatment of message payloads. It ensures the payload and user headers remain untouched by simply proxy-passing them with added trace headers.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/scheduled_messages/flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/scheduled_messages/flow.svg" />
 </p>
 <p align="center">
   <small>*Illustration presenting how Scheduled Messages work.
@@ -454,7 +454,7 @@ Karafka's Web UI displays daily dispatch estimates and the current loading state
 Additionally, the Web UI offers a detailed exploration of scheduled messages, showing specific information about each message queued for future dispatch. Users can view scheduled times, payload content, and other relevant metadata, aiding in monitoring and verifying the scheduling system's effectiveness.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/scheduled_messages.png" alt="karafka web scheduled messages state" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/scheduled_messages.png" alt="karafka web scheduled messages state" />
 </p>
 
 !!! warning "Future Day Cancellation Reporting Limitations"

--- a/Pro/Scheduling-API.md
+++ b/Pro/Scheduling-API.md
@@ -45,7 +45,7 @@ The Listener and Worker threads in Karafka are central to its architecture, work
 Below, you can find a simplified illustration of the cooperation of Listener and Worker threads and their connection via the jobs queue.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/scheduling_api/listeners_and_workers.svg" />
+  <img src="https://karafka.io/assets/misc/charts/scheduling_api/listeners_and_workers.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates how Listener and Worker threads cooperate via the jobs queue.

--- a/Pro/Virtual-Partitions.md
+++ b/Pro/Virtual-Partitions.md
@@ -5,7 +5,7 @@ While the default scaling strategy for Kafka consumers is to increase partitions
 Virtual Partitions solve this problem by providing you with the means to further parallelize work by creating "virtual" partitions that will operate independently but will, as a collective processing unit, obey all the Kafka warranties.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/performance.png" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/performance.png" />
 </p>
 <p align="center">
   <small>*This example illustrates the throughput difference for IO intense work, where the IO cost of processing a single message is 1ms.
@@ -111,7 +111,7 @@ Message distribution is based on the outcome of the `virtual_partitions` setting
 Below is a diagram illustrating an example partitioning flow of a single partition data. Each job will be picked by a separate worker and executed in parallel (or concurrently when IO is involved).
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/partitioner.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/partitioner.svg" />
 </p>
 
 ### Partitioning Based on the Message Key
@@ -400,7 +400,7 @@ Whenever you `mark_as_consumed` when using Virtual Partitions, Karafka will ensu
 Below you can find a few examples of how Karafka transforms messages marked as consumed in virtual partitions into an appropriate offset that can be committed to Kafka.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/collective_state.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/collective_state.svg" />
 </p>
 
 ### Virtual Partition Collective Marking
@@ -412,7 +412,7 @@ This functionality seamlessly integrates with collective marking to materialize 
 Below you can find an example illustrating which of the messages will be virtually marked as consumed when given message in a virtual partition is marked.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/collective_marking.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/collective_marking.svg" />
 </p>
 
 ### Reprocessing Exclusions
@@ -424,7 +424,7 @@ By automatically skipping already consumed messages upon encountering an error, 
 This behavior is advantageous in scenarios where message processing involves external systems or operations that are not idempotent. Skipping previously consumed messages reduces the risk of executing duplicate actions and helps maintain the integrity of the overall system.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/collapsed_with_exclusions.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/collapsed_with_exclusions.svg" />
 </p>
 
 ## Behaviour on Errors
@@ -432,7 +432,7 @@ This behavior is advantageous in scenarios where message processing involves ext
 For a single partition-based Virtual Partitions group, offset management and retries policies are entangled. They behave [on errors](Operations-Error-Handling-and-Back-Off-Policy#runtime) precisely the same way as regular partitions with one difference: back-offs and retries are applied to the underlying regular partition. This means that if an error occurs in one of the virtual partitions, Karafka will pause based on the highest possible Virtual Offset computed using the [Virtual Offset Management](#virtual-offset-management) feature and will exclude all the messages that were marked as consumed in any of the virtual partitions.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/error_handling.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/error_handling.svg" />
 </p>
 
 If processing in all virtual partitions ends up successfully, Karafka will mark the last message from the underlying partition as consumed.
@@ -460,7 +460,7 @@ end
 ```
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/collapse.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/collapse.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates the retry and collapse of two virtual partitions into one upon errors.
@@ -532,7 +532,7 @@ Virtual Partitions provide three types of warranties in regards to order:
 - Strong Kafka ordering warranties when operating in the `collapsed` mode with automatic exclusion of messages virtually marked as consumed.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/order.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/order.svg" />
 </p>
 <p align="center">
   <small>*Example distribution of messages in between two virtual partitions.
@@ -573,7 +573,7 @@ Karafka's architecture involves maintaining a map of consumer instances mapped t
 By decoupling thread assignment from consumer instances and ensuring dedicated, long-lived consumer instances per virtual partition, Karafka achieves a balance between flexibility and consistency. This design allows for efficient resource utilization, consistent message processing, and the ability to handle high-throughput scenarios effectively.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/virtualization_flow.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/virtualization_flow.svg" />
 </p>
 <p align="center">
   <small>*This example illustrates the flow of message distribution through virtualization and scheduling until the worker threads jobs pickup for processing.
@@ -651,7 +651,7 @@ Both `#shutdown` and `#revoked` handlers work the same as within [regular consum
 For each virtual consumer instance, both are executed when shutdown or revocation occurs. Please keep in mind that those are executed for **each** instance. That is, upon shutdown, if you used ten threads and they were all used with virtual partitions, the `#shutdown` method will be called ten times. Once per each virtual consumer instance that was in use.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/virtual_partitions/shutdown.svg" />
+  <img src="https://karafka.io/assets/misc/charts/virtual_partitions/shutdown.svg" />
 </p>
 
 ## Virtual Partitions vs. Increasing Number of Partitions vs. Parallel Segments

--- a/Pro/Web-UI.md
+++ b/Pro/Web-UI.md
@@ -19,7 +19,7 @@ There are **no** extra steps needed unless you want to completely disable consum
 
 The dashboard provides an all-encompassing insight into your Karafka operations. It’s an indispensable tool for anyone looking to monitor, optimize, and troubleshoot their Karafka processes. With its user-friendly interface and detailed metrics, you have everything you need to ensure the smooth running of your Kafka operations.
 
-<img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-dashboard.png" alt="karafka web pro dashboard view" />
+<img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-dashboard.png" alt="karafka web pro dashboard view" />
 
 ## Consumers
 
@@ -36,19 +36,19 @@ Those metrics can allow you to identify bottlenecks (CPU vs. IO) in your Karafka
 
 Consumer process inspection view provides real-time visibility into the performance and behavior of a given consumer process and its Kafka subscriptions.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-consumer-subscriptions.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-consumer-subscriptions.png)
 
 ### Consumer Jobs Inspection
 
 The consumer jobs inspection view provides real-time visibility into the jobs running at the current moment on a given consumer instance.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-consumer-jobs.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-consumer-jobs.png)
 
 ### Consumer Details Inspection
 
 This feature offers users a detailed look into each process's current state report. It's a valuable tool for thorough debugging and precise per-process inspection.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-consumer-details.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-consumer-details.png)
 
 ### Commanding
 
@@ -80,7 +80,7 @@ In the Karafka Pro Web UI, you can manage and monitor [recurring tasks](Pro-Recu
 - **Control Tasks**: Enable, disable, or trigger tasks directly from the UI.
 - **View Logs**: Access and explore execution logs to track task performance and troubleshoot issues.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/recurring-tasks.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/recurring-tasks.png)
 
 ## Scheduled Messages
 
@@ -91,7 +91,7 @@ Karafka Pro's Enhanced Web UI provides detailed insights into scheduled messages
 - **Message Exploration**: Access detailed information about messages, queued for future dispatch, including scheduled times and payload details.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/scheduled_messages.png" alt="karafka web scheduled messages state" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/scheduled_messages.png" alt="karafka web scheduled messages state" />
 </p>
 
 ## Errors
@@ -105,11 +105,11 @@ It allows for easier debuggability and error exploration, enabling users to perf
 
 Errors list:
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-errors1.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-errors1.png)
 
 Error details:
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-errors2.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-errors2.png)
 
 ## DLQ / Dead
 
@@ -121,11 +121,11 @@ Dead insights allowing to navigate through DLQ topics and messages that were dis
 
 DLQ dispatched messages view:
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-dead1.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-dead1.png)
 
 DLQ dispatched per message view:
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/dlq2.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/dlq2.png)
 
 ## Branding
 
@@ -133,7 +133,7 @@ This feature allows you to set an environment-specific notice and a menu label t
 
 This feature has its own dedicated documentation that you can access [here](Pro-Web-UI-Branding).
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/branding1.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/branding1.png)
 
 ## Policies
 
@@ -208,7 +208,7 @@ The "Topics Management" feature in Karafka Web UI allows you to create, delete, 
 
 This feature has dedicated documentation that you can access [here](Pro-Web-UI-Topics-Management).
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-configuration.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-configuration.png)
 
 ---
 

--- a/Pro/Web-UI/Branding.md
+++ b/Pro/Web-UI/Branding.md
@@ -16,7 +16,7 @@ Karafka::Web.setup do |config|
 end
 ```
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/branding1.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/branding1.png)
 
 ## Best Practices
 

--- a/Pro/Web-UI/Commanding.md
+++ b/Pro/Web-UI/Commanding.md
@@ -55,7 +55,7 @@ Alongside these details, the "Controls" tab also provides actionable commands th
 This tab serves as the operational center for managing consumers, allowing administrators to apply commands individually or in bulk, depending on the situation.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-commanding-controls.png" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-commanding-controls.png" />
 </p>
 
 #### Commands Tab
@@ -75,7 +75,7 @@ Each command in the Commands tab progresses through multiple states in its lifec
 3. **Result**: Final outcome of the command execution
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-commanding-commands.png" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-commanding-commands.png" />
 </p>
 
 ### Tracing
@@ -85,7 +85,7 @@ Tracing is a diagnostic feature that allows administrators to request backtraces
 A special command message is dispatched to the targeted consumer when the "Trace" button is pressed in the Web UI. Upon receiving this message, the consumer iterates over all Ruby threads currently running within the process and records the backtrace of each thread. These backtraces provide a snapshot of the execution stack for each thread, which can be invaluable for debugging and understanding the consumer's behavior at a particular moment. After collecting the backtraces, the consumer compiles these into a special result message that is published back to Kafka. This result message is accessible for inspection, providing real-time diagnostic information about the consumer's state.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-commanding-trace.png" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-commanding-trace.png" />
 </p>
 
 #### Use Cases
@@ -142,7 +142,7 @@ Partition-level controls are accessible from two main locations:
 2. **Consumer Subscriptions**: Navigating to a specific consumer process shows its subscriptions with partition management options
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-health.png" alt="Karafka Web UI partition controls in Health overview" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-health.png" alt="Karafka Web UI partition controls in Health overview" />
 </p>
 
 ### Pause and Resume Partitions
@@ -195,7 +195,7 @@ To pause a partition:
 5. Click **Set or Update Pause**
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-pause.png" alt="Karafka Web UI partition pause dialog" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-pause.png" alt="Karafka Web UI partition pause dialog" />
 </p>
 
 !!! warning "Running Consumer Process Operation"
@@ -224,7 +224,7 @@ To resume a paused partition:
 5. Click **Resume Processing**
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-resume.png" alt="Karafka Web UI partition resume dialog" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-resume.png" alt="Karafka Web UI partition resume dialog" />
 </p>
 
 Resuming a partition restores normal message processing operations. The resumption takes effect after the current processing cycle completes and before the next polling operation.
@@ -249,7 +249,7 @@ To adjust a partition offset:
 5. Click **Adjust Offset**
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-move.png" alt="Karafka Web UI offset editing interface" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-move.png" alt="Karafka Web UI offset editing interface" />
 </p>
 
 !!! warning "Running Consumer Process Operation"

--- a/Pro/Web-UI/Explorer.md
+++ b/Pro/Web-UI/Explorer.md
@@ -10,7 +10,7 @@ Below you can find the primary features of the Karafka Data Explorer.
 
 Before diving deep into the data, having a bird's eye view of all available topics is essential. This feature offers a list of all the topics, allowing users to select and focus on specific ones. It serves as a starting point for data exploration, giving a clear overview of the topics landscape.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-explorer1.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-explorer1.png)
 
 ### Per Topic View
 
@@ -38,7 +38,7 @@ Ever wanted to see a message generated at a particular moment? This feature faci
 
 Need to investigate messages from a specific moment in time? Karafka Web UI provides Kafka messages timestamp-based offset lookups that enable you to jump directly to messages produced at exact Unix timestamps. This feature is invaluable for incident analysis, allowing you to correlate message production with system events or errors. Enter the timestamp, and the Explorer will navigate to the corresponding offset, making historical data exploration efficient and precise.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/explorer_timestamp_input.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/explorer_timestamp_input.png)
 
 ### Real-Time Display of the Recent Message
 
@@ -48,7 +48,7 @@ Stay updated with the latest information. The explorer can display the most rece
 
 Every message is more than just its content. With the Karafka Data Explorer, you can access the complete details of any message. This includes its payload, headers, and associated metadata, ensuring a comprehensive understanding of the data.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-explorer3.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-explorer3.png)
 
 ### Message Republishing
 

--- a/Pro/Web-UI/Health.md
+++ b/Pro/Web-UI/Health.md
@@ -1,6 +1,6 @@
 The health views of the Web UI display the current status of all the running Karafka instances aggregated on a per-consumer-group basis. Those views allow users to monitor the health of their messages consumption and troubleshoot any issues that may arise including issues related to hanging transactions (LSO issues). It also allows quick identification of performance bottlenecks and can help with capacity planning.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-health.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-health.png)
 
 ## Static Membership Identification
 
@@ -39,7 +39,7 @@ Karafka's Web UI has visual cues to indicate potential problems concerning the L
     - **Web UI Indication**: The partition will be highlighted in yellow.
     - **LSO State**: "At risk"
 
-    ![karafka web ui LSO warning](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-health-lso1.png)
+    ![karafka web ui LSO warning](https://karafka.io/assets/misc/printscreens/web-ui/pro-health-lso1.png)
 
 1. **Stopped (Red Highlight)**
 
@@ -47,7 +47,7 @@ Karafka's Web UI has visual cues to indicate potential problems concerning the L
     - **Web UI Indication**: The partition will be highlighted in red, emphasizing that it is stopped.
     - **LSO State**: "Stopped".
 
-    ![karafka web ui LSO error](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-health-lso2.png)
+    ![karafka web ui LSO error](https://karafka.io/assets/misc/printscreens/web-ui/pro-health-lso2.png)
 
 These visual indicators allow immediate awareness of potential problems, ensuring quick identification and action.
 
@@ -68,7 +68,7 @@ This feature is handy in environments where:
 
 Focusing on the lag data directly from Kafka lets you gain insights into system performance and potential bottlenecks without relying solely on consumer process metrics.
 
-![karafka web ui cluster lags](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-health-cluster-lags.png)
+![karafka web ui cluster lags](https://karafka.io/assets/misc/printscreens/web-ui/pro-health-cluster-lags.png)
 
 !!! warning "Lag Reporting Limitation for Paused Partitions"
 

--- a/Pro/Web-UI/Policies.md
+++ b/Pro/Web-UI/Policies.md
@@ -160,7 +160,7 @@ end
 Below you can find an example of the effect of the usage of a similar sanitizer that removes the `visitor_id` from the displayed data:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/explorer_sanitization.png" alt="karafka web displayed data sanitization" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/explorer_sanitization.png" alt="karafka web displayed data sanitization" />
 </p>
 
 ## Example Use Cases

--- a/Pro/Web-UI/Search.md
+++ b/Pro/Web-UI/Search.md
@@ -21,7 +21,7 @@ The search modal includes several fields and options to refine your search:
 
 Once you have configured your search parameters, click the "Search" button to initiate the search. The search results and detailed metadata will be displayed, helping you analyze and understand the data based on your specified criteria.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-search1.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-search1.png)
 
 ## Reconfiguration
 
@@ -106,7 +106,7 @@ The Search Metadata Details section provides detailed insights into the performa
 
 When you initiate a search, the results page contains a hidden detailed summary and partition-specific information, offering valuable insights into the search process. You can display it by clicking the stats icon above the search results.
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-search2.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-search2.png)
 
 The summary table at the top of the Search Metadata Details section highlights three key metrics:
 
@@ -194,7 +194,7 @@ Karafka::Web.setup do |config|
 end
 ```
 
-![karafka web ui](https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-search3.png)
+![karafka web ui](https://karafka.io/assets/misc/printscreens/web-ui/pro-search3.png)
 
 The `.active?` method enables or disables matchers for specific topics. This can be useful if certain matchers are only relevant to particular types of data or topics. By default, matchers are always active.
 

--- a/Pro/Web-UI/Topics-Insights.md
+++ b/Pro/Web-UI/Topics-Insights.md
@@ -13,7 +13,7 @@ The first tab under Topics Insights is the Configuration Explorer, where users c
 This detailed breakdown helps quickly understand how each topic is configured, making it easier to manage Kafka's behavior and ensure compliance with security and operational standards.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-configuration.png" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-configuration.png" />
 </p>
 
 ## Replication
@@ -38,7 +38,7 @@ The Replication tab displays `min.insync.replicas` alongside the replication fac
 These warnings help you proactively identify topics that may need configuration adjustments to meet your durability and availability requirements.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-replication.png" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-replication.png" />
 </p>
 
 ## Distribution
@@ -53,7 +53,7 @@ The Distribution tab offers a visual and analytical perspective on the message d
 Moreover, the Distribution tab features a graph that visually represents the distribution of messages across partitions. This graphical insight can be instrumental in quickly identifying disparities in message load, guiding administrators in practical tasks such as rebalancing partitions or adjusting producer configurations to achieve a more even distribution.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-distribution.png" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-distribution.png" />
 </p>
 
 ### Benefits of Distribution Insights
@@ -74,7 +74,7 @@ Understanding offsets is useful in several scenarios:
 - **Distribution Monitoring**: Provides insights into how messages are distributed across partitions, helping identify imbalances and optimize resource allocation.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-offsets.png" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-offsets.png" />
 </p>
 
 ## Summary

--- a/Pro/Web-UI/Topics-Management.md
+++ b/Pro/Web-UI/Topics-Management.md
@@ -33,7 +33,7 @@ To create a new topic:
 1. Click the submit button to create your topic
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-create.png" alt="Karafka Web UI topic creation interface" />
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-create.png" alt="Karafka Web UI topic creation interface" />
     </p>
 
 ## Deleting Topics
@@ -66,7 +66,7 @@ To delete a topic:
 1. Confirm the deletion
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-delete.png" alt="Karafka Web UI topic deletion interface" />
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-delete.png" alt="Karafka Web UI topic deletion interface" />
     </p>
 
 ## Managing Topic Configuration
@@ -99,7 +99,7 @@ To view a topic's configuration:
     - And many more
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-configuration.png" alt="Karafka Web UI topic configuration interface" />
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-configuration.png" alt="Karafka Web UI topic configuration interface" />
     </p>
 
 ### Modifying Topic Configuration
@@ -132,7 +132,7 @@ To modify a specific configuration parameter:
 1. Enter the new value and submit the change
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-edit.png" alt="Karafka Web UI topic configuration interface" />
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-edit.png" alt="Karafka Web UI topic configuration interface" />
     </p>
 
 ## Managing Topic Partitions
@@ -171,7 +171,7 @@ To increase the number of partitions:
 1. Enter the new partition count and submit the change
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-increase.png" alt="Karafka Web UI partition management interface" />
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-topics-management-increase.png" alt="Karafka Web UI partition management interface" />
     </p>
 
 ## Best Practices

--- a/WaterDrop/About.md
+++ b/WaterDrop/About.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/karafka/waterdrop/workflows/ci/badge.svg)](https://github.com/karafka/waterdrop/actions?query=workflow%3Aci)
 [![Gem Version](https://badge.fury.io/rb/waterdrop.svg)](http://badge.fury.io/rb/waterdrop)
-[![Join the chat at https://slack.karafka.io](https://cdn.karafka.io/assets/misc/slack.svg)](https://slack.karafka.io)
+[![Join the chat at https://slack.karafka.io](https://karafka.io/assets/misc/slack.svg)](https://slack.karafka.io)
 
 WaterDrop is a standalone gem that sends messages to Kafka easily with an extra validation layer. It is a part of the [Karafka](https://github.com/karafka/karafka) ecosystem.
 

--- a/WaterDrop/Monitoring-and-Logging.md
+++ b/WaterDrop/Monitoring-and-Logging.md
@@ -106,7 +106,7 @@ end
 
 Karafka [Web UI](Web-UI-Getting-Started) is a user interface for the Karafka framework. The Web UI provides a convenient way for monitor all producers related errors out of the box.
 
-![Example producer errors in Karafka Web-UI](https://cdn.karafka.io/assets/misc/printscreens/web-ui/errors-producer.png)
+![Example producer errors in Karafka Web-UI](https://karafka.io/assets/misc/printscreens/web-ui/errors-producer.png)
 
 ## Logger Listener
 
@@ -306,7 +306,7 @@ producer.monitor.subscribe(listener)
 
 You can also find [here](https://github.com/karafka/waterdrop/blob/master/lib/waterdrop/instrumentation/vendors/datadog/dashboard.json) a ready to import DataDog dashboard configuration file that you can use to monitor all of your producers.
 
-![Example WaterDrop DD dashboard](https://cdn.karafka.io/assets/misc/printscreens/waterdrop_dd_dashboard_example.png)
+![Example WaterDrop DD dashboard](https://karafka.io/assets/misc/printscreens/waterdrop_dd_dashboard_example.png)
 
 ### Metrics Reporting Enhancement
 

--- a/WaterDrop/Transactions.md
+++ b/WaterDrop/Transactions.md
@@ -495,7 +495,7 @@ Karafka producer transactions provide atomicity over streams, but users should b
     Below, you can find an example of how the Karafka Web UI reports topic looks when all the records are created using the transactional producer:
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/explorer_transactional.png" alt="karafka web ui transactional explorer"/>
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui/explorer_transactional.png" alt="karafka web ui transactional explorer"/>
     </p>
 
 These limitations underline the importance of a thorough understanding and careful implementation when leveraging Kafka transactions, especially with tools like WaterDrop.

--- a/Web-UI/About.md
+++ b/Web-UI/About.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/karafka/karafka-web/workflows/ci/badge.svg)](https://github.com/karafka/karafka-web/actions?query=workflow%3Aci)
 [![Gem Version](https://badge.fury.io/rb/karafka-web.svg)](http://badge.fury.io/rb/karafka-web)
-[![Join the chat at https://slack.karafka.io](https://cdn.karafka.io/assets/misc/slack.svg)](https://slack.karafka.io)
+[![Join the chat at https://slack.karafka.io](https://karafka.io/assets/misc/slack.svg)](https://slack.karafka.io)
 
 Karafka Web UI is a user interface for the [Karafka framework](https://github.com/karafka/karafka). The Web UI provides a convenient way for developers to monitor and manage their Karafka-based applications, without the need to use the command line or third party software. It does **not** require any additional database beyond Kafka itself.
 
@@ -20,7 +20,7 @@ The interface, amongst others, displays:
 Karafka Web UI is shipped as a separate [gem](https://rubygems.org/gems/karafka-web) with minimal dependencies.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui.png" alt="Karafka Web UI"/>
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui.png" alt="Karafka Web UI"/>
 </p>
 
 ---

--- a/Web-UI/Components.md
+++ b/Web-UI/Components.md
@@ -23,7 +23,7 @@ This design ensures efficient resource usage - only the reports topic requires c
 Below you can find the diagram of the whole data flow:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/charts/web-ui-flow.svg" alt="karafka web ui data flow"/>
+  <img src="https://karafka.io/assets/misc/charts/web-ui-flow.svg" alt="karafka web ui data flow"/>
 </p>
 
 !!! note

--- a/Web-UI/Features.md
+++ b/Web-UI/Features.md
@@ -20,7 +20,7 @@ Below you can find a comprehensive description of the most important features yo
 
 The dashboard provides an all-encompassing insight into your Karafka operations. It’s an indispensable tool for anyone looking to monitor, optimize, and troubleshoot their Karafka processes. With its user-friendly interface and detailed metrics, you have everything you need to ensure the smooth running of your Kafka operations.
 
-<img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/dashboard.png" alt="karafka web dashboard view" />
+<img src="https://karafka.io/assets/misc/printscreens/web-ui/dashboard.png" alt="karafka web dashboard view" />
 
 ## Consumers
 
@@ -31,7 +31,7 @@ The dashboard provides an all-encompassing insight into your Karafka operations.
 The consumers status view allows users to view and monitor the performance of Kafka-running consumers. The page displays real-time data and aggregated metrics about the status of the consumers, such as their current offset, lag, the current state of consumers, and others.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/consumers.png" alt="karafka web consumers view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/consumers.png" alt="karafka web consumers view" />
 </p>
 
 The following metrics are available for each consumer:
@@ -56,7 +56,7 @@ This page provides a real-time view of the jobs that are currently being process
 - `Started at` - Since when the job is running.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/jobs.png" alt="karafka web jobs view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/jobs.png" alt="karafka web jobs view" />
 </p>
 
 ## Health
@@ -66,7 +66,7 @@ This dashboard view shows Karafka consumers' groups' health state with their lag
 [Here](Pro-Web-UI-Health) you can learn more about the information available in this dashboard view.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/health.png" alt="karafka web health view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/health.png" alt="karafka web health view" />
 </p>
 
 ## Routing
@@ -74,11 +74,11 @@ This dashboard view shows Karafka consumers' groups' health state with their lag
 The Routing UI view allows users to inspect Karafka's routing configuration, including details about particular topics. It recognizes the routing patterns, though it is worth remembering that it can take Karafka Web UI up to 5 minutes to identify and map newly detected topics due to the internal caching layer.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/routing1.png" alt="karafka web routing view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/routing1.png" alt="karafka web routing view" />
 </p>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/routing2.png" alt="karafka web routing view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/routing2.png" alt="karafka web routing view" />
 </p>
 
 ## Explorer
@@ -90,7 +90,7 @@ The Routing UI view allows users to inspect Karafka's routing configuration, inc
 Karafka Data Explorer is an essential tool for users seeking to navigate and comprehend the data produced to Kafka. Offering an intuitive interface and a deep understanding of the routing table, the explorer ensures that users can access deserialized data effortlessly for seamless viewing. You can read more about it [here](Pro-Web-UI#explorer).
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/explorer3.png" alt="karafka web explorer view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/explorer3.png" alt="karafka web explorer view" />
 </p>
 
 ## Search
@@ -102,7 +102,7 @@ Karafka Data Explorer is an essential tool for users seeking to navigate and com
 The Search feature is a tool that enables users to search and filter messages efficiently. This feature allows users to search within one or multiple partitions, start from a specific time or offset, apply custom matchers to payloads, keys, or headers, and use custom deserializers for data.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/pro-search1.png" alt="karafka web search view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/pro-search1.png" alt="karafka web search view" />
 </p>
 
 ## Errors
@@ -116,11 +116,11 @@ A Karafka errors page UI view allows users to inspect errors occurring during me
 - `Backtrace` (Pro only) - Full backtrace that shows the sequence of methods and calls that lead up to an exception (an error).
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/errors1.png" alt="karafka web errors view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/errors1.png" alt="karafka web errors view" />
 </p>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/errors2.png" alt="karafka web error view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/errors2.png" alt="karafka web error view" />
 </p>
 
 ## DLQ / Dead
@@ -132,11 +132,11 @@ A Karafka errors page UI view allows users to inspect errors occurring during me
 The Dead Letter Queue (DLQ) dashboard allows users to view messages that have failed to be processed and were skipped and moved to the Dead Letter Queue topic with their original details.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/dlq1.png" alt="karafka web dlq view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/dlq1.png" alt="karafka web dlq view" />
 </p>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/dlq2.png" alt="karafka web dlq view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/dlq2.png" alt="karafka web dlq view" />
 </p>
 
 ## Cluster
@@ -144,7 +144,7 @@ The Dead Letter Queue (DLQ) dashboard allows users to view messages that have fa
 The Cluster dashboard view displays information about the status of the Kafka cluster and the topics list.
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/cluster1.png" alt="karafka web cluster view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/cluster1.png" alt="karafka web cluster view" />
 </p>
 
 ## Status
@@ -185,7 +185,7 @@ Each check may display one of the following statuses:
 </table>
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/status.png" alt="karafka web status view" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/status.png" alt="karafka web status view" />
 </p>
 
 ---

--- a/Web-UI/Getting-Started.md
+++ b/Web-UI/Getting-Started.md
@@ -63,7 +63,7 @@ To use it:
     If you do everything right, you should see this in your browser:
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui.png" alt="Karafka Web UI"/>
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui.png" alt="Karafka Web UI"/>
     </p>
 
 ## Karafka Web CLI commands

--- a/Web-UI/Multi-App.md
+++ b/Web-UI/Multi-App.md
@@ -27,7 +27,7 @@ Here are the steps necessary to configure Karafka Web-UI to work in a multi-app 
 1. Deploy all the applications, open the Web UI, and enjoy.
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/multi-app.png" alt="karafka web multi-app processes view" />
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui/multi-app.png" alt="karafka web multi-app processes view" />
     </p>
 
 !!! warning "Critical Setup Requirement"

--- a/Web-UI/Tagging.md
+++ b/Web-UI/Tagging.md
@@ -17,7 +17,7 @@ Karafka::Process.tags.add(:machine_type, machine_type)
 ```
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/tags-emoji.png" alt="karafka web emoji tagging presentation" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/tags-emoji.png" alt="karafka web emoji tagging presentation" />
 </p>
 
 ## Taggable resources
@@ -92,13 +92,13 @@ Process tags will be visible in the following places:
 In the consumers' main view for each process:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/tags-process1.png" alt="karafka web tagging presentation" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/tags-process1.png" alt="karafka web tagging presentation" />
 </p>
 
 In the consumer detailed view (Karafka Pro only):
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/tags-process2.png" alt="karafka web tagging presentation" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/tags-process2.png" alt="karafka web tagging presentation" />
 </p>
 
 ## Managing consumer work-related tags
@@ -133,13 +133,13 @@ Consumer tags will be visible in the following places:
 In the jobs overview page:
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/tags-job1.png" alt="karafka web tagging presentation" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/tags-job1.png" alt="karafka web tagging presentation" />
 </p>
 
 In the consumer jobs detailed view (Karafka Pro only):
 
 <p align="center">
-  <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/tags-job2.png" alt="karafka web tagging presentation" />
+  <img src="https://karafka.io/assets/misc/printscreens/web-ui/tags-job2.png" alt="karafka web tagging presentation" />
 </p>
 
 ---

--- a/Web-UI/Transactions.md
+++ b/Web-UI/Transactions.md
@@ -11,7 +11,7 @@ There are a few things worth keeping in mind if you work with transactional data
     Below, you can find an example of how the Karafka Web UI reports topic looks when all the records are created using the transactional producer:
 
     <p align="center">
-      <img src="https://cdn.karafka.io/assets/misc/printscreens/web-ui/explorer_transactional.png" alt="karafka web ui transactional explorer"/>
+      <img src="https://karafka.io/assets/misc/printscreens/web-ui/explorer_transactional.png" alt="karafka web ui transactional explorer"/>
     </p>
 
 - **Limitations with "Recent" Feature**: Given the offset-based nature of the Karafka Explorer, the "Recent" feature, which typically displays the latest entries, might encounter difficulties if the first ten pages predominantly consist of aborted messages and system entries.


### PR DESCRIPTION
## Summary
- Replace all `cdn.karafka.io` image URLs with `karafka.io`
- Images are now served via Cloudflare on the main domain

## Test plan
- [ ] Verify images load correctly from the new URLs