### PR TITLE
Add karafka-testing to Components list

### DIFF
--- a/Components.md
+++ b/Components.md
@@ -4,6 +4,7 @@ Karafka is a robust, Ruby-based framework for building Kafka-driven applications
 - **[WaterDrop](https://github.com/karafka/waterdrop)** – dedicated message production library optimized for high-performance and reliable delivery to Kafka clusters
 - **[Karafka-Web](https://github.com/karafka/karafka-web)** –  User Interface providing real-time visibility into application operations
 - **[Karafka-Rdkafka](https://github.com/karafka/karafka-rdkafka)** – custom fork of rdkafka-ruby that enhances functionality and stability for production environments
+- **[Karafka-Testing](https://github.com/karafka/karafka-testing)** – testing library providing RSpec and Minitest helpers for testing Karafka consumers and producers without a live Kafka cluster
 - **[Rdkafka-Ruby](https://github.com/appsignal/rdkafka-ruby/)** – base driver providing low-level Ruby bindings for the librdkafka C/C++ library, maintained by our team
 
 ## Producer


### PR DESCRIPTION
## Summary
- Adds the karafka-testing gem to the Components page bullet list
- The gem was already documented in other places (Testing.md, Home.md changelogs/code docs) but missing from the main components overview

## Test plan
- [x] Verified with `npm run lint` - no errors