### PR TITLE
Update SBOM versions for librdkafka and daisyUI

### DIFF
--- a/Advanced/SBOM.md
+++ b/Advanced/SBOM.md
@@ -230,7 +230,7 @@ This page exists because of our commitment to security, compliance, and transpar
       daisyUI
     </td>
     <td>
-      5.5.5
+      5.5.17
     </td>
     <td>
       <a rel="nofollow noopener noreferrer" href="https://github.com/saadeghi/daisyui/blob/master/LICENSE">MIT</a>
@@ -400,7 +400,7 @@ This page exists because of our commitment to security, compliance, and transpar
     <td>
       librdkafka
     </td>
-    <td>2.12.1</td>
+    <td>2.13.0</td>
     <td>
       <a rel="nofollow noopener noreferrer" href="https://github.com/confluentinc/librdkafka/blob/master/LICENSE">BSD-2-Clause</a>
     </td>


### PR DESCRIPTION
## Summary

- Update librdkafka version from 2.12.1 to 2.13.0 (matches karafka-rdkafka)
- Update daisyUI version from 5.5.5 to 5.5.17 (matches karafka-web)

## Verification

- Licenses verified: both components retain their original licenses (BSD-2-Clause for librdkafka, MIT for daisyUI)
- Versions confirmed against source repositories