### PR TITLE
chore(deps): standardize Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,5 +22,6 @@
       ],
       "groupName": "ruby setup"
     }
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
Standardizes Renovate configuration across all repositories:

- Use default schedule (removes custom Monday schedules)
- Set `minimumReleaseAge: "7 days"` (cooldown period)
- Remove automerge rules (all PRs require manual merge)

This ensures consistent dependency update behavior across all repos.