### PR TITLE
Add WaterDrop 2.9 upgrade guide

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -247,6 +247,7 @@ It is recommended to do one major upgrade at a time.
     - [0.3](Upgrades-Web-UI-0.3)
 
 - [WaterDrop](Upgrades-WaterDrop)
+    - [2.9](Upgrades-WaterDrop-2.9)
     - [2.8](Upgrades-WaterDrop-2.8)
     - [2.7](Upgrades-WaterDrop-2.7)
     - [2.6](Upgrades-WaterDrop-2.6)

--- a/Upgrades/WaterDrop/2.7.md
+++ b/Upgrades/WaterDrop/2.7.md
@@ -1,7 +1,5 @@
 # Upgrading to WaterDrop 2.7
 
-**PLEASE MAKE SURE TO READ AND APPLY THEM!**
-
 ## `wait_timeout` Configuration No Longer Needed
 
 The `wait_timeout` WaterDrop configuration option is no longer needed. You can safely remove it.

--- a/Upgrades/WaterDrop/2.8.md
+++ b/Upgrades/WaterDrop/2.8.md
@@ -1,7 +1,5 @@
 # Upgrading to WaterDrop 2.8
 
-**PLEASE MAKE SURE TO READ AND APPLY THEM!**
-
 ## `throw(:abort)` No Longer Allowed To Abort Transactions
 
 Replace:

--- a/Upgrades/WaterDrop/2.9.md
+++ b/Upgrades/WaterDrop/2.9.md
@@ -18,6 +18,10 @@ producer.setup do |config|
 end
 ```
 
+!!! note "Experiencing Issues?"
+
+    If you experience any issues with the `:fd` polling mode, please [open an issue](https://github.com/karafka/waterdrop/issues/new) on the WaterDrop GitHub repository. Your feedback will help us improve the FD mode before the `:thread` mode is removed.
+
 !!! warning "Deprecation Timeline"
 
     The `:thread` polling mode will be deprecated in WaterDrop 2.10 and removed in 2.11. If you need to revert, plan to migrate to `:fd` before 2.11.

--- a/Upgrades/WaterDrop/2.9.md
+++ b/Upgrades/WaterDrop/2.9.md
@@ -1,0 +1,96 @@
+# Upgrading to WaterDrop 2.9
+
+**PLEASE MAKE SURE TO READ AND APPLY THEM!**
+
+## Default Polling Mode Changed from `:thread` to `:fd`
+
+WaterDrop 2.9 switches the default polling mode from `:thread` to `:fd`. The FD mode uses a single Ruby thread with `IO.select` for efficient multiplexing, providing higher throughput, lower memory usage, and fewer threads compared to the thread-based mode.
+
+If you experience any issues with the new default, you can revert to the previous behavior:
+
+```ruby
+producer = WaterDrop::Producer.new
+
+producer.setup do |config|
+  config.deliver = true
+  config.polling.mode = :thread
+  # ...
+end
+```
+
+!!! warning "Deprecation Timeline"
+
+    The `:thread` polling mode will be deprecated in WaterDrop 2.10 and removed in 2.11. If you need to revert, plan to migrate to `:fd` before 2.11.
+
+## Statistics Decorator Scope Reduced
+
+The built-in statistics decorator now only decorates keys used by the Datadog metrics listener (`tx`, `txretries`, `txerrs`, `rxerrs`) and skips unused subtrees (`topics`, broker window stats). This reduces decoration cost by ~425x on large clusters.
+
+If you rely on other `_d` or `_fd` delta keys in custom instrumentation, you need to provide a custom decorator:
+
+```ruby
+producer = WaterDrop::Producer.new
+
+producer.setup do |config|
+  config.deliver = true
+
+  # Provide a custom decorator that includes the keys you need
+  config.statistics_decorator = ::Karafka::Core::Monitoring::StatisticsDecorator.new(
+    only_keys: %w[tx txretries txerrs rxerrs your_custom_key],
+    excluded_keys: %w[]
+  )
+  # ...
+end
+```
+
+If you do not use custom statistics instrumentation beyond the built-in Datadog listener, no action is needed.
+
+## Default Timeout Values Increased 3x
+
+Default timeout values have been upscaled 3x, closer to librdkafka defaults, to prevent intermediate timeouts during node recovery:
+
+<table>
+  <thead>
+    <tr>
+      <th>Config</th>
+      <th>Previous Default</th>
+      <th>New Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>kafka <code>message.timeout.ms</code></td>
+      <td>50000 ms (50 seconds)</td>
+      <td>150000 ms (150 seconds)</td>
+    </tr>
+    <tr>
+      <td>kafka <code>transaction.timeout.ms</code></td>
+      <td>55000 ms (55 seconds)</td>
+      <td>165000 ms (165 seconds)</td>
+    </tr>
+    <tr>
+      <td>root <code>max_wait_timeout</code></td>
+      <td>60000 ms (60 seconds)</td>
+      <td>180000 ms (180 seconds)</td>
+    </tr>
+  </tbody>
+</table>
+
+If you want to retain previous timeout behavior, set them explicitly:
+
+```ruby
+producer = WaterDrop::Producer.new
+
+producer.setup do |config|
+  config.deliver = true
+  config.max_wait_timeout = 60_000
+
+  config.kafka = {
+    'bootstrap.servers': 'localhost:9092',
+    'message.timeout.ms': 50_000,
+    'transaction.timeout.ms': 55_000
+  }
+end
+```
+
+These higher defaults provide more resilience during broker recovery scenarios and reduce the likelihood of premature timeout errors in production environments.

--- a/Upgrades/WaterDrop/2.9.md
+++ b/Upgrades/WaterDrop/2.9.md
@@ -20,7 +20,7 @@ end
 
 !!! note "Experiencing Issues?"
 
-    If you experience any issues with the `:fd` polling mode, please [open an issue](https://github.com/karafka/waterdrop/issues/new) on the WaterDrop GitHub repository. Your feedback will help us improve the FD mode before the `:thread` mode is removed.
+    If you experience any issues with the `:fd` polling mode, please [open an issue](https://github.com/karafka/waterdrop/issues/new) on the WaterDrop GitHub repository. Your feedback will help improve the FD mode before the `:thread` mode is removed.
 
 !!! warning "Deprecation Timeline"
 
@@ -28,7 +28,7 @@ end
 
 ## Statistics Decorator Scope Reduced
 
-The built-in statistics decorator now only decorates keys used by the Datadog metrics listener (`tx`, `txretries`, `txerrs`, `rxerrs`) and skips unused subtrees (`topics`, broker window stats). This reduces decoration cost by ~425x on large clusters.
+The built-in statistics decorator now only decorates keys used by the Karafka official metrics listeners (`tx`, `txretries`, `txerrs`, `rxerrs`) and skips unused subtrees (`topics`, broker window stats). This reduces decoration cost by ~425x on large clusters.
 
 If you rely on other `_d` or `_fd` delta keys in custom instrumentation, you need to provide a custom decorator:
 
@@ -47,7 +47,7 @@ producer.setup do |config|
 end
 ```
 
-If you do not use custom statistics instrumentation beyond the built-in Datadog listener, no action is needed.
+If you do not use custom statistics instrumentation beyond the built-in listeners, no action is needed.
 
 ## Default Timeout Values Increased 3x
 

--- a/Upgrades/WaterDrop/2.9.md
+++ b/Upgrades/WaterDrop/2.9.md
@@ -1,7 +1,5 @@
 # Upgrading to WaterDrop 2.9
 
-**PLEASE MAKE SURE TO READ AND APPLY THEM!**
-
 ## Default Polling Mode Changed from `:thread` to `:fd`
 
 WaterDrop 2.9 switches the default polling mode from `:thread` to `:fd`. The FD mode uses a single Ruby thread with `IO.select` for efficient multiplexing, providing higher throughput, lower memory usage, and fewer threads compared to the thread-based mode.

--- a/WaterDrop/Configuration.md
+++ b/WaterDrop/Configuration.md
@@ -131,19 +131,19 @@ The reload mechanism helps ensure that transient fatal errors don't permanently 
 
 ## Polling Configuration
 
-WaterDrop supports two polling modes that control how librdkafka delivery callbacks are processed: `:thread` (default) and `:fd`.
+WaterDrop supports two polling modes that control how librdkafka delivery callbacks are processed: `:fd` (default) and `:thread`.
 
-### Thread Mode (Default)
-
-In thread mode, each producer spawns a dedicated background Ruby thread that continuously calls `rd_kafka_poll` in a loop. This is the simplest approach and works well for most use cases.
-
-No additional configuration is required to use thread mode, as it is the default.
-
-### FD Mode
+### FD Mode (Default)
 
 FD mode uses OS-level pipes and `IO.select` multiplexing to monitor all producers from a single Ruby thread, avoiding GVL contention. This approach provides **39-54% higher throughput** compared to thread mode, making it ideal for high-performance applications or environments with many producers.
 
-To enable FD mode:
+No additional configuration is required to use FD mode, as it is the default.
+
+### Thread Mode
+
+In thread mode, each producer spawns a dedicated background Ruby thread that continuously calls `rd_kafka_poll` in a loop.
+
+To use thread mode:
 
 ```ruby
 producer = WaterDrop::Producer.new do |config|
@@ -152,7 +152,7 @@ producer = WaterDrop::Producer.new do |config|
     'bootstrap.servers': 'localhost:9092'
   }
 
-  config.polling.mode = :fd
+  config.polling.mode = :thread
 end
 ```
 
@@ -162,7 +162,7 @@ The following options are available under the `config.polling` namespace:
 
 | Option                | Description                                                                                        | Default   |
 |-----------------------|----------------------------------------------------------------------------------------------------|-----------|
-| `polling.mode`        | Polling mode to use: `:thread` (dedicated thread per producer) or `:fd` (`IO.select` multiplexing) | `:thread` |
+| `polling.mode`        | Polling mode to use: `:fd` (`IO.select` multiplexing) or `:thread` (dedicated thread per producer) | `:fd`     |
 | `polling.fd.max_time` | Maximum time in milliseconds spent polling a single producer per cycle in FD mode                  | `100`     |
 | `polling.poller`      | Custom `WaterDrop::Polling::Poller` instance for callback isolation                                | `nil`     |
 
@@ -174,14 +174,12 @@ In FD mode, you can use `polling.fd.max_time` to differentiate polling priority 
 # High-priority producer: more time per polling cycle
 high_priority = WaterDrop::Producer.new do |config|
   config.kafka = { 'bootstrap.servers': 'localhost:9092' }
-  config.polling.mode = :fd
   config.polling.fd.max_time = 200
 end
 
 # Low-priority producer: less time per polling cycle
 low_priority = WaterDrop::Producer.new do |config|
   config.kafka = { 'bootstrap.servers': 'localhost:9092' }
-  config.polling.mode = :fd
   config.polling.fd.max_time = 50
 end
 ```
@@ -195,7 +193,6 @@ dedicated_poller = WaterDrop::Polling::Poller.new
 
 producer = WaterDrop::Producer.new do |config|
   config.kafka = { 'bootstrap.servers': 'localhost:9092' }
-  config.polling.mode = :fd
   config.polling.poller = dedicated_poller
 end
 ```


### PR DESCRIPTION
Cover breaking changes: default polling mode switch to :fd, statistics decorator scope reduction, and 3x timeout default increases.