### PR TITLE
docs: document multi-credential support for Pro licenses

### DIFF
--- a/Pro/FAQ.md
+++ b/Pro/FAQ.md
@@ -187,7 +187,9 @@ Licenses are **not** transferrable to another company. It is strongly recommende
 
 ## Do I have to share the credentials with all of my developers?
 
-In general, **yes**. The credentials are required to download the gems and your developers will need the gems to use the commercial features.
+Not necessarily. You can create up to 5 additional credential pairs from your license page, each with its own label (e.g. "development", "ci"). This allows you to issue separate credentials for different teams or environments without sharing a single set. Each additional credential can be independently rotated or removed.
+
+If you prefer not to use multiple credentials, sharing the primary credentials with your developers also remains a valid approach.
 
 ## Can I get a refund?
 

--- a/Pro/Getting-Started.md
+++ b/Pro/Getting-Started.md
@@ -29,6 +29,12 @@ To activate Karafka Pro, you need to do three things:
 
     An Enterprise license is required if you are looking into hosting the license key offline within the app or via a private registry. This mode of operation allows you to use Karafka Pro without relying on our gem server. An Enterprise Agreement will grant you access to the license gem sources and installation instructions, ensuring you can proceed smoothly with your preferred setup.
 
+## Additional Credentials
+
+You can create up to 5 additional credential pairs from your license page for different environments or teams (e.g. development, CI). Each additional credential provides its own username and password that can be used in place of the primary credential in your `Gemfile`. Additional credentials can be individually rotated or removed without affecting other credentials.
+
+To manage additional credentials, visit your license credentials page and use the "Add credential" form.
+
 ## License Gem Integrity Verification
 
 !!! info "Checksum Verification in Enterprise Mode Not Needed"

--- a/Pro/Rotating-Credentials.md
+++ b/Pro/Rotating-Credentials.md
@@ -1,6 +1,8 @@
 If your credentials leak due to internal or external incidents, you should rotate them.
 
-To do so:
+## Rotating the Primary Credential
+
+To rotate your primary (main) credential:
 
 1. Go to your license credentials page.
 
@@ -8,7 +10,7 @@ To do so:
       <img src="https://karafka.io/assets/misc/printscreens/gems_license_page.png" />
     </p>
 
-1. Press the "Rotate credentials" button.
+1. Press the "Rotate" button next to the main credential.
 
 1. Read the disclaimers.
 
@@ -21,6 +23,10 @@ To do so:
 1. Click on the link received in the email.
 
 1. View your new credentials and replace them in your Gemfile and any other place where you use them.
+
+## Rotating Additional Credentials
+
+If you use [additional credentials](Pro-Getting-Started#additional-credentials) (e.g. for CI or development environments), each one can be rotated independently from the license page. Press the "Rotate" button next to the specific credential you want to rotate and follow the same email confirmation flow. Only the rotated credential is affected; all other credentials remain unchanged.
 
 ---
 


### PR DESCRIPTION
Update Pro docs to reflect the new ability to create up to 5 additional credential pairs per license for different environments (dev, CI, etc.).