### PR TITLE
docs: mark Kafka Coordinator Recovery API advisory as resolved

### DIFF
--- a/Status.md
+++ b/Status.md
@@ -3,16 +3,16 @@
 !!! info "About This Page"
     This page tracks external incidents and ecosystem-level disruptions that may affect Karafka, WaterDrop, and Web UI users. This is **not** a Karafka uptime status page, but a curated log of upstream issues, dependency problems, and third-party service disruptions relevant to the Karafka ecosystem.
 
-!!! warning "Current Status - Active Advisory"
-    One active advisory. See details below.
+!!! success "Current Status - All Clear"
+    No active advisories at this time.
 
 ---
 
 ## Incident History
 
-!!! warning "[IN PROGRESS] March 2026 - Kafka Coordinator Recovery API Under Development"
+!!! success "[RESOLVED] March 2026 - Kafka Coordinator Recovery API"
 
-    - **Status:** In Progress
+    - **Status:** Resolved
     - **Impact:** Medium
     - **Affected:** Karafka users experiencing Kafka group coordinator `FAILED` state (`not_coordinator` errors)
 
@@ -32,7 +32,7 @@
     - Use Kafka CLI tools (`kafka-reassign-partitions`, `kafka-leader-election`, `kafka-consumer-groups`) to force a coordinator reload on a healthy broker
     - File a support ticket with your managed Kafka provider (MSK, Confluent Cloud) to apply upstream Kafka patches
 
-    **Resolution:** A new `Karafka::Admin::Recovery` API is under active development. This API will allow users to read committed offsets directly from the `__consumer_offsets` log (bypassing the broken coordinator), assess the blast radius across consumer groups, and migrate offsets to a new healthy consumer group - all without broker-level intervention. This issue will be fully resolved once the new version of Karafka containing the Recovery API is released.
+    **Resolution:** The [`Karafka::Admin::Recovery` API](https://karafka.io/docs/Infrastructure-Admin-Recovery-API) has been shipped. It allows users to read committed offsets directly from the `__consumer_offsets` log (bypassing the broken coordinator), assess the blast radius across consumer groups, and migrate offsets to a new healthy consumer group - all without broker-level intervention.
 
 !!! success "[RESOLVED] February 11, 2026 - Pro License Server Hardware Failure"
 


### PR DESCRIPTION
The Karafka::Admin::Recovery API has shipped, so the March 2026 advisory is no longer in progress. Update the page header to All Clear and link to the new Recovery API documentation.