### PR TITLE
docs: add resolved April 2026 statistics memory bloat advisory

### DIFF
--- a/Status.md
+++ b/Status.md
@@ -16,14 +16,14 @@
     - **Impact:** Medium
     - **Affected:** Karafka users running against clusters with high partition counts (thousands of partitions per topic)
 
-    On large Kafka clusters, the statistics mechanism emitted by the underlying client produced payloads that scaled with the total number of partitions known to the client, not just the partitions assigned to a given process. This caused oversized statistics payloads, excessive memory allocations on every statistics interval, and noticeable RSS growth and GC pressure in long-running consumer and producer processes.
+    On large Kafka clusters, the statistics mechanism emitted by the underlying client produced extensive payloads that caused excessive memory allocations on every statistics interval, along with noticeable RSS growth and GC pressure in long-running consumer and producer processes.
 
     **Symptoms:**
 
     - Steadily growing RSS memory in consumer and producer processes on large clusters
     - High CPU usage tied to statistics decoration and deserialization
     - Frequent GC collections correlated with the `statistics.interval.ms` cadence
-    - Stats payloads in the megabytes range even for processes assigned only a small subset of partitions
+    - Stats payloads in the megabytes range on long-running processes
 
     **Resolution:** Karafka Pro now ships with [Optimized Statistics Processing](https://karafka.io/docs/Pro-Optimized-Statistics-Processing) that automatically reduces the size and processing cost of statistics so they scale with the actual workload of a given process rather than the size of the cluster. The optimization is transparent and requires no configuration changes.
 

--- a/Status.md
+++ b/Status.md
@@ -10,6 +10,23 @@
 
 ## Incident History
 
+!!! success "[RESOLVED] April 2026 - Karafka Statistics Memory Bloat on Large Clusters"
+
+    - **Status:** Resolved
+    - **Impact:** Medium
+    - **Affected:** Karafka users running against clusters with high partition counts (thousands of partitions per topic)
+
+    On large Kafka clusters, the statistics mechanism emitted by the underlying client produced payloads that scaled with the total number of partitions known to the client, not just the partitions assigned to a given process. This caused oversized statistics payloads, excessive memory allocations on every statistics interval, and noticeable RSS growth and GC pressure in long-running consumer and producer processes.
+
+    **Symptoms:**
+
+    - Steadily growing RSS memory in consumer and producer processes on large clusters
+    - High CPU usage tied to statistics decoration and deserialization
+    - Frequent GC collections correlated with the `statistics.interval.ms` cadence
+    - Stats payloads in the megabytes range even for processes assigned only a small subset of partitions
+
+    **Resolution:** Karafka Pro now ships with [Optimized Statistics Processing](https://karafka.io/docs/Pro-Optimized-Statistics-Processing) that automatically reduces the size and processing cost of statistics so they scale with the actual workload of a given process rather than the size of the cluster. The optimization is transparent and requires no configuration changes.
+
 !!! success "[RESOLVED] March 2026 - Kafka Coordinator Recovery API"
 
     - **Status:** Resolved

--- a/Status.md
+++ b/Status.md
@@ -16,7 +16,7 @@
     - **Impact:** Medium
     - **Affected:** Karafka users running against clusters with high partition counts (thousands of partitions per topic)
 
-    On large Kafka clusters, the statistics mechanism emitted by the underlying client produced extensive payloads that caused excessive memory allocations on every statistics interval, along with noticeable RSS growth and GC pressure in long-running consumer and producer processes.
+    On large Kafka clusters, the statistics pipeline produced extensive payloads that caused excessive memory allocations on every statistics interval, along with noticeable RSS growth and GC pressure in long-running consumer and producer processes.
 
     **Symptoms:**
 


### PR DESCRIPTION
Document the large-cluster statistics memory bloat issue and link to the Pro Optimized Statistics Processing page that resolves it.