### PR TITLE
chore(renovate): add internalChecksFilter strict to ruby setup group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
         "ruby/setup-ruby",
         "ruby"
       ],
-      "groupName": "ruby setup"
+      "groupName": "ruby setup",
+      "internalChecksFilter": "strict"
     }
   ],
   "labels": [


### PR DESCRIPTION
Ensures Renovate waits until both ruby and ruby/setup-ruby have cleared the minimumReleaseAge window before creating the grouped PR, preventing partial dependency update PRs that fail CI.