### PR TITLE
Update ruby/setup-ruby to v1.310.0

### DIFF
--- a/.github/workflows/refresh-automatic-content.yml
+++ b/.github/workflows/refresh-automatic-content.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         token: ${{ secrets.REPO_TOKEN }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: '4.0.5'
     - name: Refresh Karafka integrations catalog

--- a/.github/workflows/sync-github-wiki.yml
+++ b/.github/workflows/sync-github-wiki.yml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.REPO_TOKEN }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: '4.0.5'
 


### PR DESCRIPTION
Update the setup-ruby action to v1.310.0 which includes support for Ruby 4.0.5.