### PR TITLE
docs: add Web UI 1.0 upgrade guide and reference Karafka 2.6 in Home.md

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -232,6 +232,7 @@
 It is recommended to do one major upgrade at a time.
 
 - [Karafka](Upgrades-Karafka)
+    - [2.6](Upgrades-Karafka-2.6)
     - [2.5](Upgrades-Karafka-2.5)
     - [2.4](Upgrades-Karafka-2.4)
     - [2.3](Upgrades-Karafka-2.3)
@@ -240,6 +241,7 @@ It is recommended to do one major upgrade at a time.
     - [2.0](Upgrades-Karafka-2.0)
 
 - [Web UI](Upgrades-Web-UI)
+    - [1.0](Upgrades-Web-UI-1.0)
     - [0.11](Upgrades-Web-UI-0.11)
     - [0.10](Upgrades-Web-UI-0.10)
     - [0.9](Upgrades-Web-UI-0.9)

--- a/Upgrades/Karafka/2.6.md
+++ b/Upgrades/Karafka/2.6.md
@@ -36,11 +36,11 @@ config.pause.with_exponential_backoff = true
 
 ## Karafka Web UI Promoted to 1.0
 
-Karafka Web UI reaches its **1.0 release** alongside Karafka 2.6. The 0.x versioning was always a conservative choice, not a reflection of stability - Web UI has been production-ready and free of major breaking changes for a long time, and there is no longer a reason to signal otherwise through a sub-1.0 version number.
+Karafka Web UI reaches its 1.0 release alongside Karafka 2.6. The 0.x versioning was always a conservative choice, not a reflection of stability - Web UI has been production-ready and free of major breaking changes for a long time, and there is no longer a reason to signal otherwise through a sub-1.0 version number.
 
 No migration steps are required. This is a version number promotion only.
 
-Looking ahead, Web UI versioning will **align with Karafka's major version** starting with Karafka 3.0, at which point Web UI will also release as 3.0. From that point on, the major version of both gems will move in lockstep.
+Looking ahead, Web UI versioning will align with Karafka's major version starting with Karafka 3.0, at which point Web UI will also release as 3.0. From that point on, the major version of both gems will move in lockstep.
 
 ## New Declarative Topics API
 

--- a/Upgrades/Karafka/2.6.md
+++ b/Upgrades/Karafka/2.6.md
@@ -34,6 +34,14 @@ config.pause.max_timeout = 30_000
 config.pause.with_exponential_backoff = true
 ```
 
+## Karafka Web UI Promoted to 1.0
+
+Karafka Web UI reaches its **1.0 release** alongside Karafka 2.6. The 0.x versioning was always a conservative choice, not a reflection of stability - Web UI has been production-ready and free of major breaking changes for a long time, and there is no longer a reason to signal otherwise through a sub-1.0 version number.
+
+No migration steps are required. This is a version number promotion only.
+
+Looking ahead, Web UI versioning will **align with Karafka's major version** starting with Karafka 3.0, at which point Web UI will also release as 3.0. From that point on, the major version of both gems will move in lockstep.
+
 ## New Declarative Topics API
 
 The Declarative Topics system has been redesigned with a standalone `declaratives.draw` DSL that lives independently of routing. This change resolves a fundamental mismatch that grew more visible as Karafka adoption spread: many teams use Karafka as the single source of truth for their entire Kafka topic infrastructure, not just the topics their application consumes. Under the old model, topic declarations were embedded inside routing blocks. This meant that to declare and manage a topic - whether for another team's service, a shared audit log, or a produce-only sink - you had to add it to your routing, which implies consumption intent and brings all the routing validation and consumer machinery along with it. The two concerns leaked into each other in a way that could not scale cleanly.

--- a/Upgrades/Web-UI.md
+++ b/Upgrades/Web-UI.md
@@ -1,5 +1,6 @@
 # Web UI Upgrade Notes
 
+- [Upgrading to 1.0](Upgrades-Web-UI-1.0)
 - [Upgrading to 0.11](Upgrades-Web-UI-0.11)
 - [Upgrading to 0.10](Upgrades-Web-UI-0.10)
 - [Upgrading to 0.9](Upgrades-Web-UI-0.9)

--- a/Upgrades/Web-UI/1.0.md
+++ b/Upgrades/Web-UI/1.0.md
@@ -2,7 +2,7 @@
 
 !!! tip "Version Compatibility Requirement"
 
-    Karafka Web UI `1.0` **requires** Karafka `2.6` - these components must be upgraded together. Attempting to run Web UI `1.0` with older versions of Karafka will result in compatibility errors. Please ensure you upgrade both components as part of the same deployment process. Karafka `2.6` Upgrade Guide can be found [here](Upgrades-Karafka-2.6).
+    Karafka Web UI `1.0` requires Karafka `2.6` - these components must be upgraded together. Attempting to run Web UI `1.0` with older versions of Karafka will result in compatibility errors. Please ensure you upgrade both components as part of the same deployment process. Karafka `2.6` Upgrade Guide can be found [here](Upgrades-Karafka-2.6).
 
 Before upgrading to Karafka Web UI `1.0`, please review our [General Karafka Upgrade Guide](Upgrades-Upgrading) first. This document provides essential advice on upgrading Karafka and its components and general best practices to ensure a smooth transition. The general guide contains fundamental steps that apply to all upgrades, while this specific guide focuses only on the changes introduced in the Web UI `1.0` release. Following both guides will help you navigate the upgrade process with minimal disruption to your production systems.
 
@@ -16,25 +16,9 @@ Starting with Karafka `3.0`, Web UI versioning will align with Karafka's major v
 
 The CSRF protection mechanism has been replaced. The previous token-based approach (`route_csrf` plugin) has been removed in favour of header-based protection using the `Sec-Fetch-Site` header (`sec_fetch_site_csrf` plugin).
 
-**For most users this is transparent** - all modern browsers automatically include the `Sec-Fetch-Site` header and the new approach requires no changes to your application.
+For most users this is transparent - all modern browsers automatically include the `Sec-Fetch-Site` header and the new approach requires no changes to your application.
 
 If you have non-browser clients, custom HTTP clients, or integration tests that send requests directly to the Web UI without browser-standard headers, those clients will need to include the `Sec-Fetch-Site: same-origin` (or `same-site`) header. Requests lacking this header will be rejected as potential cross-site forgeries.
-
-## Roda Dependency Update
-
-The minimum required version of Roda has been raised from `~> 3.69` to `>= 3.100`.
-
-If your `Gemfile` pins Roda to a specific version or uses a restrictive constraint, update it to allow `>= 3.100`:
-
-```ruby
-# Before (if you had an explicit pin)
-gem 'roda', '~> 3.69'
-
-# After
-gem 'roda', '>= 3.100'
-```
-
-If you do not pin Roda explicitly, Bundler will resolve the new minimum automatically.
 
 ## Dynamic Worker Count in the UI
 

--- a/Upgrades/Web-UI/1.0.md
+++ b/Upgrades/Web-UI/1.0.md
@@ -1,0 +1,62 @@
+# Upgrading to Web UI 1.0
+
+!!! tip "Version Compatibility Requirement"
+
+    Karafka Web UI `1.0` **requires** Karafka `2.6` - these components must be upgraded together. Attempting to run Web UI `1.0` with older versions of Karafka will result in compatibility errors. Please ensure you upgrade both components as part of the same deployment process. Karafka `2.6` Upgrade Guide can be found [here](Upgrades-Karafka-2.6).
+
+Before upgrading to Karafka Web UI `1.0`, please review our [General Karafka Upgrade Guide](Upgrades-Upgrading) first. This document provides essential advice on upgrading Karafka and its components and general best practices to ensure a smooth transition. The general guide contains fundamental steps that apply to all upgrades, while this specific guide focuses only on the changes introduced in the Web UI `1.0` release. Following both guides will help you navigate the upgrade process with minimal disruption to your production systems.
+
+## Version Numbering Change
+
+Web UI `1.0` is the direct successor to `0.11.x` — there are **no breaking changes** to configuration, the public API, or behavior between `0.11.7` and `1.0`. The version was promoted from `0.x` to `1.0` to reflect the long-standing production stability of the Web UI. No migration steps are required on account of the version number change alone.
+
+Starting with Karafka `3.0`, Web UI versioning will align with Karafka's major version — both will release as `3.0` together and move in lockstep from that point forward.
+
+## CSRF Protection Change
+
+The CSRF protection mechanism has been replaced. The previous token-based approach (`route_csrf` plugin) has been removed in favour of header-based protection using the `Sec-Fetch-Site` header (`sec_fetch_site_csrf` plugin).
+
+**For most users this is transparent** — all modern browsers automatically include the `Sec-Fetch-Site` header and the new approach requires no changes to your application.
+
+If you have non-browser clients, custom HTTP clients, or integration tests that send requests directly to the Web UI without browser-standard headers, those clients will need to include the `Sec-Fetch-Site: same-origin` (or `same-site`) header. Requests lacking this header will be rejected as potential cross-site forgeries.
+
+## Roda Dependency Update
+
+The minimum required version of Roda has been raised from `~> 3.69` to `>= 3.100`.
+
+If your `Gemfile` pins Roda to a specific version or uses a restrictive constraint, update it to allow `>= 3.100`:
+
+```ruby
+# Before (if you had an explicit pin)
+gem 'roda', '~> 3.69'
+
+# After
+gem 'roda', '>= 3.100'
+```
+
+If you do not pin Roda explicitly, Bundler will resolve the new minimum automatically.
+
+## Dynamic Worker Count in the UI
+
+The Web UI now reads the live worker count from `Karafka::Server.workers.size` instead of the static `Karafka::App.config.concurrency` value. This means the UI accurately reflects runtime thread pool changes when dynamic worker pool scaling (introduced in Karafka `2.6`) is in use.
+
+No configuration change is required. The display updates automatically.
+
+## Poll Interval Monitoring
+
+Consumer reporting now tracks `poll_interval` (`max.poll.interval.ms`) per subscription group alongside the existing `poll_age` metric. This gives you visibility into how close each subscription group is to its polling timeout, helping catch slow consumers before they are kicked out of the group.
+
+The consumer schema has been bumped to **1.7.0** to carry this additional field.
+
+## Deployment
+
+Because of the consumer schema version bump to `1.7.0`, follow the standard zero-downtime upgrade procedure:
+
+1. Make sure you have upgraded to `0.11.7` before and that it was fully deployed.
+1. Test the upgrade on a staging or dev environment.
+1. The Web UI interface may throw 500 errors during the upgrade because of schema incompatibility (until Puma is redeployed and all consumers are replaced). This will have no long-term effects and can be ignored.
+1. `Karafka::Web::Errors::Processing::IncompatibleSchemaError` **is expected**. It is part of the Karafka Web UI zero-downtime deployment strategy. This error allows the Web UI materialization consumer to back off and wait for it to be replaced with a new one.
+1. Perform a rolling deployment (or a regular one) and replace all consumer processes.
+1. Update the Web UI Puma.
+1. **No** CLI command execution is required.
+1. Enjoy.

--- a/Upgrades/Web-UI/1.0.md
+++ b/Upgrades/Web-UI/1.0.md
@@ -8,15 +8,15 @@ Before upgrading to Karafka Web UI `1.0`, please review our [General Karafka Upg
 
 ## Version Numbering Change
 
-Web UI `1.0` is the direct successor to `0.11.x` — there are **no breaking changes** to configuration, the public API, or behavior between `0.11.7` and `1.0`. The version was promoted from `0.x` to `1.0` to reflect the long-standing production stability of the Web UI. No migration steps are required on account of the version number change alone.
+Web UI `1.0` is the direct successor to `0.11.x` - there are **no breaking changes** to configuration, the public API, or behavior between `0.11.7` and `1.0`. The version was promoted from `0.x` to `1.0` to reflect the long-standing production stability of the Web UI. No migration steps are required on account of the version number change alone.
 
-Starting with Karafka `3.0`, Web UI versioning will align with Karafka's major version — both will release as `3.0` together and move in lockstep from that point forward.
+Starting with Karafka `3.0`, Web UI versioning will align with Karafka's major version - both will release as `3.0` together and move in lockstep from that point forward.
 
 ## CSRF Protection Change
 
 The CSRF protection mechanism has been replaced. The previous token-based approach (`route_csrf` plugin) has been removed in favour of header-based protection using the `Sec-Fetch-Site` header (`sec_fetch_site_csrf` plugin).
 
-**For most users this is transparent** — all modern browsers automatically include the `Sec-Fetch-Site` header and the new approach requires no changes to your application.
+**For most users this is transparent** - all modern browsers automatically include the `Sec-Fetch-Site` header and the new approach requires no changes to your application.
 
 If you have non-browser clients, custom HTTP clients, or integration tests that send requests directly to the Web UI without browser-standard headers, those clients will need to include the `Sec-Fetch-Site: same-origin` (or `same-site`) header. Requests lacking this header will be rejected as potential cross-site forgeries.
 


### PR DESCRIPTION
- Add Upgrades/Web-UI/1.0.md covering the 0.11→1.0 version promotion, CSRF protection change, Roda >=3.100 requirement, dynamic worker count display, poll_interval monitoring, and deployment notes for schema 1.7.0
- Register the new guide in Upgrades/Web-UI.md and Home.md
- Add Karafka 2.6 entry to the Home.md upgrade index
- Note Web UI 1.0 promotion and future 3.0 version alignment in the Karafka 2.6 upgrade guide