### PR TITLE
Fix license verification snippet: insulate ruby from Bundler stdout pollution

### DIFF
--- a/Pro/Getting-Started.md
+++ b/Pro/Getting-Started.md
@@ -118,8 +118,14 @@ if [ "$MODE" != "after" ]; then
     -o ./karafka-license.gem
 else
   # Check the local cached one after bundle install
-  cache_path=`ruby -e 'puts "#{Gem.dir}/cache/"'`
-  cp "$cache_path/karafka-license-$KARAFKA_PRO_LICENSE_ID.gem" ./karafka-license.gem
+  #
+  # Run ruby insulated from Bundler: when this script is invoked from a
+  # Bundler-aware context (e.g. under `bundle exec`), RUBYOPT carries
+  # bundler/setup into the subshell and, with auto-install enabled, Bundler
+  # may print "Resolving dependencies..." to stdout, corrupting the captured
+  # path
+  cache_path=$(RUBYOPT='' BUNDLE_AUTO_INSTALL='false' ruby -e 'print "#{Gem.dir}/cache/"')
+  cp "${cache_path}karafka-license-$KARAFKA_PRO_LICENSE_ID.gem" ./karafka-license.gem
 fi
 
 detected=`sha256sum ./karafka-license.gem | awk '{ print $1 }'`


### PR DESCRIPTION
When the post-install verification runs from a Bundler-aware context (e.g. under `bundle exec`), RUBYOPT carries bundler/setup into the `ruby -e` subshell. With auto_install enabled, Bundler prints "Resolving dependencies..." to stdout, which the command substitution captures into cache_path, breaking the subsequent cp with:

  cp: cannot stat 'Resolving dependencies...'$'\n''/...gems/3.3.0/cache//karafka-license-*.gem'

Clear RUBYOPT and disable auto-install for the path lookup, and drop the duplicated slash (cache_path already ends with /).