### PR TITLE
Document forceful shutdown and forceful_shutdown_wait

### DIFF
--- a/Infrastructure/Signals-and-States.md
+++ b/Infrastructure/Signals-and-States.md
@@ -46,6 +46,20 @@ Use `TSTP` + `TERM` to guarantee shut down within a period. The best practice is
 
 Send `TERM` or `QUIT` signal to a Karafka process to shut it down. It will stop accepting new work but continue working on current messages.  Workers who do not finish within the `shutdown_timeout` are forcefully terminated.
 
+#### Forceful Shutdown
+
+When one or more jobs do not finish within the `shutdown_timeout`, Karafka escalates to a **forceful shutdown**: it terminates the still-running workers and listeners, closes the Kafka clients, and then exits immediately with [exit code](Infrastructure-Exit-codes) `2`.
+
+A forceful shutdown is a **last resort**, and it is **expected that in-flight data may be lost**. Because the process ends with an immediate `exit!`, the regular `ensure`-based cleanup is skipped and the producer is **not** flushed: any async-buffered messages that have not yet been delivered - for example user `produce_async` calls or Dead Letter Queue copies - may be discarded.
+
+This is intentional. Flushing the producer during a forceful shutdown would be risky exactly when it matters most: the producer (or its connection pool) may itself be the resource that is blocked - for example an unreachable broker - and waiting on it could stall or even hang the forceful exit whose entire purpose is to guarantee the process terminates.
+
+The blocking cleanup that Karafka does perform on this path (stopping the listeners' underlying clients) is time-boxed by the `forceful_shutdown_wait` setting - it defaults to `5_000` (milliseconds) and can be adjusted via `config.internal.forceful_shutdown_wait` - so that a hung resource cannot delay the forceful exit indefinitely.
+
+!!! note "Preventing Data Loss on Shutdown"
+
+    If losing in-flight buffered data on shutdown is unacceptable for your workload, do not rely on the forceful path. Make sure jobs finish within `shutdown_timeout` - extend it to match your processing patterns, or investigate what is running longer than expected - so that shutdown completes gracefully and the producer is flushed normally.
+
 ## States
 
 The Karafka process can be in a few states during its lifecycle, and each has a separate meaning and indicates different things happening internally.


### PR DESCRIPTION
Explain the graceful->forceful shutdown escalation, the producer flush before exit!, and that forceful_shutdown_wait is a per-stage (not total) budget - so a fully stuck forceful shutdown can take up to ~2x the configured value. Note the supervisor grace-period relationship.