### PR TITLE
docs: use bare wiki slugs for internal links; enable no-md-link-exten…

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -65,6 +65,6 @@
     "max-sentence-length": false,
     "no-markdown-tables": false,
     "no-generic-admonition-title": false,
-    "no-md-link-extension": false
+    "no-md-link-extension": true
   }
 }

--- a/.rules/no-md-link-extension.js
+++ b/.rules/no-md-link-extension.js
@@ -8,6 +8,11 @@ module.exports = {
   tags: ['style', 'links'],
   parser: 'markdownit',
   function: function rule(params, onError) {
+    // The repo README is a GitHub file, not a wiki page - its links (for example
+    // ](LICENSE.md)) follow GitHub file-link conventions, so skip it.
+    if (/(^|\/)README\.md$/i.test(params.name || '')) {
+      return;
+    }
     const lines = params.lines;
     let inCodeBlock = false;
     const linkTarget = /\]\(([^)]+)\)/g;

--- a/Development/Code-Quality-Linting-Setup.md
+++ b/Development/Code-Quality-Linting-Setup.md
@@ -109,6 +109,6 @@ BUNDLE_GEMFILE=Gemfile.lint bundle exec yard-lint lib/
 
 ## See Also
 
-- [Technical Writing](Development-Technical-Writing.md) - Documentation style guidelines
-- [Naming Conventions](Development-Naming-Conventions.md) - Naming patterns across Karafka
-- [Gems Publishing](Development-Gems-Publishing.md) - Release process for Karafka gems
+- [Technical Writing](Development-Technical-Writing) - Documentation style guidelines
+- [Naming Conventions](Development-Naming-Conventions) - Naming patterns across Karafka
+- [Gems Publishing](Development-Gems-Publishing) - Release process for Karafka gems

--- a/WaterDrop/Usage.md
+++ b/WaterDrop/Usage.md
@@ -261,7 +261,7 @@ KAFKA_PRODUCER.produce_sync(topic: 'my-topic', payload: 'my message')
 
 ## Usage With Connection Pool
 
-WaterDrop provides a built-in [`ConnectionPool`](WaterDrop-Connection-Pool.md) for efficient producer management in high-intensity applications. This eliminates the need for external connection pooling gems and provides optimized connection handling with instrumentation events.
+WaterDrop provides a built-in [`ConnectionPool`](WaterDrop-Connection-Pool) for efficient producer management in high-intensity applications. This eliminates the need for external connection pooling gems and provides optimized connection handling with instrumentation events.
 
 ```ruby
 # Configure the connection pool
@@ -292,7 +292,7 @@ WaterDrop.monitor.subscribe('connection_pool.shutdown') do |event|
 end
 ```
 
-For detailed information about connection pool usage, events, and lifecycle management, see the [Connection Pool documentation](WaterDrop-Connection-Pool.md).
+For detailed information about connection pool usage, events, and lifecycle management, see the [Connection Pool documentation](WaterDrop-Connection-Pool).
 
 ## Buffering
 
@@ -386,7 +386,7 @@ While `#close!` can be helpful when you want to finalize your application quickl
 
 ### Connection Pool Shutdown
 
-If you're using [connection pools](WaterDrop-Connection-Pool.md) in your application, you need to explicitly close them just like producers. Connection pools manage their own resources independently and must be shut down separately to prevent resource leaks:
+If you're using [connection pools](WaterDrop-Connection-Pool) in your application, you need to explicitly close them just like producers. Connection pools manage their own resources independently and must be shut down separately to prevent resource leaks:
 
 ```ruby
 # Close your connection pool instance
@@ -399,7 +399,7 @@ WaterDrop::ConnectionPool.close
 producer.close
 ```
 
-You can monitor connection pool shutdown operations using WaterDrop's connection pool instrumentation events. For detailed information about connection pool usage, lifecycle events, and proper shutdown procedures, see the [Connection Pool documentation](WaterDrop-Connection-Pool.md).
+You can monitor connection pool shutdown operations using WaterDrop's connection pool instrumentation events. For detailed information about connection pool usage, lifecycle events, and proper shutdown procedures, see the [Connection Pool documentation](WaterDrop-Connection-Pool).
 
 ### Closing Producer Used in Karafka
 


### PR DESCRIPTION
…sion

Convert the 7 internal wiki cross-links that included .md to bare slugs (Development/Code-Quality-Linting-Setup.md x3, WaterDrop/Usage.md x4), matching the ~1160 bare-slug links already used across the docs.

- Skip the repo README in the rule: its ](LICENSE.md) is a GitHub file link, not a wiki page.
- The Librdkafka/Changelog.md .md references are in an auto-generated, lint-excluded file and are left as-is.
- Enable no-md-link-extension in .markdownlint-cli2.jsonc so CI keeps internal links slug-only.