### PR TITLE
docs: give admonitions descriptive titles; enable no-generic-admonition-title

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -64,7 +64,7 @@
     "no-unapproved-terms": false,
     "max-sentence-length": false,
     "no-markdown-tables": false,
-    "no-generic-admonition-title": false,
+    "no-generic-admonition-title": true,
     "no-md-link-extension": true
   }
 }

--- a/.rules/no-generic-admonition-title.js
+++ b/.rules/no-generic-admonition-title.js
@@ -1,9 +1,24 @@
-// Admonitions must have a DESCRIPTIVE title that states the takeaway, not the
-// bare type word (for example !!! note "Note"). Complements admonition-title-required,
+// Admonitions must have a DESCRIPTIVE title that states the takeaway - not the
+// bare type word, not a low-content placeholder ("Important Note", "Please Read"),
+// and not something too short to say anything. Complements admonition-title-required,
 // which only checks that a title exists. Skips fenced code blocks.
+
+// Placeholder titles that satisfy "has a title" but carry no information.
+const GENERIC_TITLES = new Set([
+  'note', 'notes', 'info', 'information', 'warning', 'warn', 'tip', 'hint',
+  'danger', 'success', 'example', 'abstract', 'summary', 'quote', 'question',
+  'faq', 'bug', 'failure', 'caution', 'error', 'important', 'important note',
+  'please note', 'please read', 'read this', 'read me', 'heads up', 'fyi',
+  'attention', 'notice', 'psa', 'reminder', 'todo', 'to do', 'nb', 'disclaimer'
+]);
+
+function wordCount(text) {
+  return (text.trim().match(/[A-Za-z0-9]+/g) || []).length;
+}
+
 module.exports = {
   names: ['no-generic-admonition-title'],
-  description: 'Admonition titles must be descriptive, not the bare type word',
+  description: 'Admonition titles must be descriptive, not a placeholder or too short',
   tags: ['style', 'admonitions'],
   parser: 'markdownit',
   function: function rule(params, onError) {
@@ -23,10 +38,26 @@ module.exports = {
       }
 
       const match = admonition.exec(trimmed);
-      if (match && match[2].trim().toLowerCase() === match[1].toLowerCase()) {
+      if (!match) {
+        continue;
+      }
+      const type = match[1].toLowerCase();
+      const title = match[2].trim();
+      const normalized = title.toLowerCase();
+
+      let problem = null;
+      if (normalized === type) {
+        problem = `repeats the type ("${title}")`;
+      } else if (GENERIC_TITLES.has(normalized)) {
+        problem = `is a generic placeholder ("${title}")`;
+      } else if (wordCount(title) < 2) {
+        problem = `is too short to state a takeaway ("${title}")`;
+      }
+
+      if (problem) {
         onError({
           lineNumber: i + 1,
-          detail: `Admonition title "${match[2]}" just repeats the type. Use a descriptive title that states the takeaway.`,
+          detail: `Admonition title ${problem}. Use a descriptive title that states the takeaway.`,
           context: trimmed
         });
       }

--- a/Basics/Articles-and-Other-References.md
+++ b/Basics/Articles-and-Other-References.md
@@ -12,7 +12,7 @@
 
 ## Articles and references about Karafka
 
-!!! note "Note"
+!!! note "Some Articles May Be Outdated"
 
     Some of those might be outdated and may refer to previous Karafka versions. Keep that in mind.
 

--- a/Basics/Configuration.md
+++ b/Basics/Configuration.md
@@ -18,7 +18,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-!!! note "Note"
+!!! note "Settings Can Be Redefined Per Topic"
 
     Karafka allows you to redefine some of the settings per each topic, which means that you can have a specific custom configuration that might differ from the default one configured at the app level. This allows you, for example, to connect to multiple Kafka clusters.
 
@@ -68,7 +68,7 @@ end
 
 Your external components will be automatically configured once per process after Karafka completes its initialization sequence.
 
-!!! note "Note"
+!!! note "Config Has Access to Finalized Settings"
     The configuration will have access to all finalized Karafka settings and can reliably use framework components like loggers, metrics, and other initialized resources.
 
 ## Environment variables settings
@@ -79,7 +79,7 @@ There are several env settings you can use with Karafka. They are described unde
 
 Kafka lets you compress your messages as they travel over the wire. By default, producer messages are sent uncompressed.
 
-!!! note "Note"
+!!! note "Supported Producer Compression Types"
 
     Karafka producer ([WaterDrop](https://github.com/karafka/waterdrop)) supports the following compression types:
 
@@ -112,7 +112,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-!!! note "Note"
+!!! note "zstd Requires libzstd-dev"
 
     To use `zstd`, you need to install `libzstd-dev`:
 

--- a/Basics/Configuration.md
+++ b/Basics/Configuration.md
@@ -22,7 +22,7 @@ end
 
     Karafka allows you to redefine some of the settings per each topic, which means that you can have a specific custom configuration that might differ from the default one configured at the app level. This allows you, for example, to connect to multiple Kafka clusters.
 
-!!! tip "Important"
+!!! tip "Use a Distinct client_id Per Instance"
 
     kafka `client.id` is a string passed to the server when making requests. It is used to track the source of requests beyond just IP/port by allowing a logical application name to be included in server-side request logging. Therefore, the `client_id` should **not** be shared across multiple instances in a cluster or a horizontally scaled application but distinct for each application instance.
 

--- a/Basics/Configuration.md
+++ b/Basics/Configuration.md
@@ -22,7 +22,7 @@ end
 
     Karafka allows you to redefine some of the settings per each topic, which means that you can have a specific custom configuration that might differ from the default one configured at the app level. This allows you, for example, to connect to multiple Kafka clusters.
 
-!!! tip "Use a Distinct client_id Per Instance"
+!!! tip "Use a Distinct `client_id` Per Instance"
 
     kafka `client.id` is a string passed to the server when making requests. It is used to track the source of requests beyond just IP/port by allowing a logical application name to be included in server-side request logging. Therefore, the `client_id` should **not** be shared across multiple instances in a cluster or a horizontally scaled application but distinct for each application instance.
 
@@ -112,7 +112,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-!!! note "zstd Requires libzstd-dev"
+!!! note "`zstd` Requires `libzstd-dev`"
 
     To use `zstd`, you need to install `libzstd-dev`:
 

--- a/Basics/Consuming-Messages.md
+++ b/Basics/Consuming-Messages.md
@@ -212,11 +212,11 @@ It is worth noting, however, that under normal operating conditions, Karafka wil
 
 In most cases, especially if you do not use [Long-Running Jobs](Pro-Consumer-Groups-Long-Running-Jobs), the Karafka default [offset management](Consumer-Groups-Offset-management) strategy should be more than enough. It ensures that, after batch processing and upon rebalances, all offsets are committed before partition reassignment. In a healthy system with stable deployment procedures and without frequent short-lived consumer generations, the number of re-processings should be close to zero.
 
-!!! note "revoked? Works Without Marking Messages"
+!!! note "`#revoked?` Works Without Marking Messages"
 
     The `#revoked?` method detects partition revocation immediately. You don't need to mark messages as consumed for it to detect revocation.
 
-!!! note "revoked? Changes Independently With Long-Running Jobs"
+!!! note "`#revoked?` Changes Independently With Long-Running Jobs"
 
     With [Long-Running Jobs](Pro-Consumer-Groups-Long-Running-Jobs), `#revoked?` result also changes independently from marking messages.
 

--- a/Basics/Consuming-Messages.md
+++ b/Basics/Consuming-Messages.md
@@ -182,7 +182,7 @@ To configure the initial offset for specific topics:
 
     **Result:** Each topic will use its configured offset position, overriding the global default.
 
-!!! note "Note"
+!!! note "Initial Offset Applies Only on First Run"
 
     This setting applies only to the first execution of a Karafka process. All following executions will pick up from the last offset where the process ended previously.
 
@@ -212,11 +212,11 @@ It is worth noting, however, that under normal operating conditions, Karafka wil
 
 In most cases, especially if you do not use [Long-Running Jobs](Pro-Consumer-Groups-Long-Running-Jobs), the Karafka default [offset management](Consumer-Groups-Offset-management) strategy should be more than enough. It ensures that, after batch processing and upon rebalances, all offsets are committed before partition reassignment. In a healthy system with stable deployment procedures and without frequent short-lived consumer generations, the number of re-processings should be close to zero.
 
-!!! note "Note"
+!!! note "revoked? Works Without Marking Messages"
 
     The `#revoked?` method detects partition revocation immediately. You don't need to mark messages as consumed for it to detect revocation.
 
-!!! note "Note"
+!!! note "revoked? Changes Independently With Long-Running Jobs"
 
     With [Long-Running Jobs](Pro-Consumer-Groups-Long-Running-Jobs), `#revoked?` result also changes independently from marking messages.
 
@@ -231,7 +231,7 @@ Karafka consumer instances are persistent by default. A single consumer instance
 
 Karafka recreates the consumer instance only when a partition is lost and reassigned.
 
-!!! note "Note"
+!!! note "Use Manual Offsets When Buffering In Memory"
 
     When buffering messages in memory, use manual offset management. Without it, you'll lose buffered data, if the process crashes before flushing.
 

--- a/Basics/FAQ.md
+++ b/Basics/FAQ.md
@@ -10,6 +10,6 @@ The Karafka FAQ is organized into the following categories for easier navigation
 | [Error Handling and DLQ](Basics-FAQ-Error-Handling-and-DLQ) | DLQ strategies, poison pills, retries, backoff, validation | 17 |
 | [Web UI](Basics-FAQ-Web-UI) | Web UI setup, topics, ACLs, monitoring, Datadog | 23 |
 
-!!! note "Note"
+!!! note "See Pro Docs for Pro Questions"
 
     For Pro-specific questions, please refer to the relevant Pro feature documentation pages.

--- a/Basics/FAQ/Configuration.md
+++ b/Basics/FAQ/Configuration.md
@@ -174,7 +174,7 @@ require 'karafka_root_dir/karafka_app'
 
 Still not a perfect solution because karafka gem is still loaded.
 
-!!! note "Note"
+!!! note "Description Prepared by AleksanderSzyszka"
 
     This description was prepared by [AleksanderSzyszka](https://github.com/AleksanderSzyszka).
 
@@ -285,7 +285,7 @@ end
 
 It is essential to keep in mind that increasing the maximum payload size may impact the performance of your Kafka cluster, so you should carefully consider the trade-offs before making any changes.
 
-!!! note "Note"
+!!! note "Errors From Exceeding max_payload_size"
 
     If you do not allow bigger payloads and try to send them, you will end up with one of the following errors:
 

--- a/Basics/FAQ/Configuration.md
+++ b/Basics/FAQ/Configuration.md
@@ -174,9 +174,7 @@ require 'karafka_root_dir/karafka_app'
 
 Still not a perfect solution because karafka gem is still loaded.
 
-!!! note "Description Prepared by AleksanderSzyszka"
-
-    This description was prepared by [AleksanderSzyszka](https://github.com/AleksanderSzyszka).
+This description was prepared by [AleksanderSzyszka](https://github.com/AleksanderSzyszka).
 
 ## Can I consume from more than one Kafka cluster simultaneously?
 
@@ -285,7 +283,7 @@ end
 
 It is essential to keep in mind that increasing the maximum payload size may impact the performance of your Kafka cluster, so you should carefully consider the trade-offs before making any changes.
 
-!!! note "Errors From Exceeding max_payload_size"
+!!! note "Errors From Exceeding `max_payload_size`"
 
     If you do not allow bigger payloads and try to send them, you will end up with one of the following errors:
 

--- a/Basics/FAQ/Consuming.md
+++ b/Basics/FAQ/Consuming.md
@@ -175,7 +175,7 @@ Here's an explanation of the benefits of marking each message as consumed:
 
 - Handling Long-running Processing: If the processing time for each message is significant, explicitly marking them as consumed provides better visibility into the progress. It allows you to identify any potential bottlenecks or delays in processing and take appropriate actions if needed.
 
-!!! note "Note"
+!!! note "Mark Each Message With Virtual Partitions"
 
     When using Karafka [Virtual Partitions](Pro-Consumer-Groups-Virtual-Partitions), it is recommended to mark each message as consumed due to how [Virtual Offset Management](Pro-Consumer-Groups-Virtual-Partitions#virtual-offset-management) works.
 

--- a/Basics/FAQ/Error-Handling-and-DLQ.md
+++ b/Basics/FAQ/Error-Handling-and-DLQ.md
@@ -51,7 +51,7 @@ When a message is dispatched to a [dead letter queue](Consumer-Groups-Dead-Lette
 
 On the other hand, if `auto.create.topics.enable` is set to `false`, Kafka will not auto-create the topic, and instead, an error will be raised when trying to produce to the non-existent DLQ topic. This error could be a topic authorization exception if the client doesn't have permission to create topics or `unknown_topic_or_part` if the topic doesn't exist and auto-creation is disabled.
 
-!!! note "Note"
+!!! note "Production Often Disables Topic Auto-Creation"
 
     In production environments, `auto.create.topics.enable` is often set to `false` to prevent unintended topic creation.
 

--- a/Basics/FAQ/Producing.md
+++ b/Basics/FAQ/Producing.md
@@ -319,7 +319,7 @@ Karafka.producer.monitor.subscribe(
 )
 ```
 
-!!! note "error.occurred Also Captures librdkafka Errors"
+!!! note "`error.occurred` Also Captures librdkafka Errors"
 
     `error.occurred` will also include any errors originating from `librdkafka` for synchronous operations, including those that are raised back to the end user.
 
@@ -537,7 +537,7 @@ With inverted ordering (`message.timeout.ms` < `socket.timeout.ms`): the message
 
     Before WaterDrop 2.9.0, `message.timeout.ms` defaulted to 50,000ms while librdkafka's `socket.timeout.ms` defaults to 60,000ms - the inverted case. Every ProduceRequest on a stale socket exhausts the message budget with no retry possible. Upgrade to WaterDrop >= 2.9.0, or explicitly set `message.timeout.ms` above `socket.timeout.ms` on older versions.
 
-!!! note "msg_timed_out Means Unconfirmed, Not Necessarily Lost"
+!!! note "`msg_timed_out` Means Unconfirmed, Not Necessarily Lost"
 
     When a ProduceRequest times out, the broker may have already committed the write before the client gave up. Delivery status is **POSSIBLY_PERSISTED** - unconfirmed, not guaranteed lost. Use idempotent or transactional producers if exactly-once semantics are required.
 

--- a/Basics/FAQ/Producing.md
+++ b/Basics/FAQ/Producing.md
@@ -319,7 +319,7 @@ Karafka.producer.monitor.subscribe(
 )
 ```
 
-!!! note "Note"
+!!! note "error.occurred Also Captures librdkafka Errors"
 
     `error.occurred` will also include any errors originating from `librdkafka` for synchronous operations, including those that are raised back to the end user.
 

--- a/Basics/Producing-Messages.md
+++ b/Basics/Producing-Messages.md
@@ -46,7 +46,7 @@ Before shutting down the Karafka producer in processes such as Puma, Sidekiq, or
 
 This is because the `#close` method ensures that any pending messages in the producer buffer are flushed to the Kafka broker before shutting down the producer.
 
-!!! info "Skipping #close Loses Messages and Leaks Resources"
+!!! info "Skipping `#close` Loses Messages and Leaks Resources"
 
     If you do not call `#close`, there is a risk that some messages may not be sent to the Kafka broker, resulting in lost or incomplete data. In addition, calling `#close` also releases any resources held by the producer, such as network connections, file handles, and memory buffers. Failing to release these resources can lead to memory leaks, socket exhaustion, or other system-level issues that can impact the stability and performance of your application.
 

--- a/Basics/Producing-Messages.md
+++ b/Basics/Producing-Messages.md
@@ -54,7 +54,7 @@ Overall, calling `#close` on the Karafka producer is a best practice that helps 
 
 In the following sections, you can find an example of how to `#close` the producer used in various Ruby processes.
 
-!!! warning "Do Not Close Producer With Embedding API"
+!!! warning "Do Not Manually Close the Producer When Embedding"
 
     Note, that you should **not** close the producer manually if you are using the [Embedding API](Infrastructure-Embedding) in the same process.
 

--- a/Basics/Producing-Messages.md
+++ b/Basics/Producing-Messages.md
@@ -46,7 +46,7 @@ Before shutting down the Karafka producer in processes such as Puma, Sidekiq, or
 
 This is because the `#close` method ensures that any pending messages in the producer buffer are flushed to the Kafka broker before shutting down the producer.
 
-!!! info "Info"
+!!! info "Skipping #close Loses Messages and Leaks Resources"
 
     If you do not call `#close`, there is a risk that some messages may not be sent to the Kafka broker, resulting in lost or incomplete data. In addition, calling `#close` also releases any resources held by the producer, such as network connections, file handles, and memory buffers. Failing to release these resources can lead to memory leaks, socket exhaustion, or other system-level issues that can impact the stability and performance of your application.
 
@@ -54,7 +54,7 @@ Overall, calling `#close` on the Karafka producer is a best practice that helps 
 
 In the following sections, you can find an example of how to `#close` the producer used in various Ruby processes.
 
-!!! warning "Warning"
+!!! warning "Do Not Close Producer With Embedding API"
 
     Note, that you should **not** close the producer manually if you are using the [Embedding API](Infrastructure-Embedding) in the same process.
 

--- a/Basics/Testing.md
+++ b/Basics/Testing.md
@@ -473,7 +473,7 @@ class UsersBuilderTest < ActiveSupport::TestCase
 end
 ```
 
-!!! note "Note"
+!!! note "Minitest Transaction Testing Mirrors RSpec"
 
     If you're seeking guidance on testing transactions with Minitest, consult the RSpec transactions testing documentation, as the testing methods are similar for both.
 

--- a/Basics/Testing.md
+++ b/Basics/Testing.md
@@ -196,7 +196,7 @@ karafka.produce_to(
 )
 ```
 
-!!! note "When to Use produce_to"
+!!! note "When to Use `#produce_to`"
 
     Use `#produce_to` when you have multiple consumer groups subscribing to the same topic. For single-consumer scenarios, the standard `#produce` method works as expected.
 

--- a/Consumer-Groups/Active-Job.md
+++ b/Consumer-Groups/Active-Job.md
@@ -61,7 +61,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-!!! note "Note"
+!!! note "Pro Enhanced Adapter Adds More Features"
 
     [Pro Enhanced ActiveJob](Pro-Consumer-Groups-Enhanced-Active-Job) adapter supports `Long-Running Jobs`, `Virtual Partitions`, `Ordered Jobs`, `Scheduled Jobs`, and other Pro features.
 

--- a/Consumer-Groups/Concurrency-and-Multithreading.md
+++ b/Consumer-Groups/Concurrency-and-Multithreading.md
@@ -46,7 +46,7 @@ Example of work distribution amongst two workers:
   <img src="https://karafka.io/assets/misc/charts/processing-workers.svg" />
 </p>
 
-!!! note "Note"
+!!! note "Virtual Partitions Parallelize a Single Partition"
 
     Please keep in mind that if you scale horizontally and end up with one Karafka process being subscribed only to a single topic partition, you can still process data from it in parallel using the **Virtual Partitions** feature.
 
@@ -100,15 +100,15 @@ end
   </small>
 </p>
 
-!!! note "Note"
+!!! note "Karafka May Create More Subscription Groups"
 
     This example is a simplification. Depending on other factors, Karafka may create more subscription groups to manage the resources better. It will, however, never group topics together that are within different subscription groups.
 
-!!! note "Note"
+!!! note "Subscription Groups Differ From Consumer Groups"
 
     Subscription groups are a different concept than consumer groups. It is an internal Karafka concept; you can have many subscription groups in one consumer group.
 
-!!! note "Note"
+!!! note "How librdkafka Fetches Messages"
 
     If you are interested in how `librdkafka` fetches messages, please refer to [this](https://github.com/edenhill/librdkafka/wiki/FAQ#how-are-partitions-fetched) documentation.
 

--- a/Consumer-Groups/Dead-Letter-Queue.md
+++ b/Consumer-Groups/Dead-Letter-Queue.md
@@ -202,7 +202,7 @@ This functionality is available in Karafka Pro, and you can read about it [here]
 
 Messages dispatched to the DLQ topic preserve both `payload` and `headers`. They do **not** follow any partitioning strategy and will be distributed randomly.
 
-!!! note "Note"
+!!! note "Original Offset and Partition Not Preserved"
 
     The original offset, partition, and topic information will **not** be preserved. If you need those, we recommend you use the [Enhanced Dead Letter Queue](Pro-Consumer-Groups-Enhanced-Dead-Letter-Queue).
 
@@ -271,7 +271,7 @@ When working with a DLQ pattern and using Karafka multi-cluster support, please 
 
 You can alter this by overriding the `#producer` consumer method and providing your cluster-specific producer instance.
 
-!!! note "Note"
+!!! note "Use One Producer Per Cluster"
 
     Do **not** create producer instances per consumer but one per cluster. Karafka producer is thread-safe and can operate from multiple consumers simultaneously.
 

--- a/Consumer-Groups/Error-Handling-and-Back-Off-Policy.md
+++ b/Consumer-Groups/Error-Handling-and-Back-Off-Policy.md
@@ -110,7 +110,7 @@ class EventsConsumer < ApplicationConsumer
 end
 ```
 
-!!! note "Note"
+!!! note "Retried Batches May Contain Different Messages"
 
     Please note that `retrying?` indicates that an error occurred previously, but you may receive fewer or more messages and previously.
 
@@ -181,7 +181,7 @@ Karafka.monitor.subscribe 'error.occurred' do |event|
 end
 ```
 
-!!! note "Note"
+!!! note "Batch Errors May Not Pinpoint the Message"
 
     When doing batch operations, this message may not be the exact cause of the processing error.
 
@@ -201,7 +201,7 @@ Karafka keeps track of the last committed offset alongside Kafka when you mark a
   <img src="https://karafka.io/assets/misc/charts/on_errors_behaviour.svg" />
 </p>
 
-!!! note "Note"
+!!! note "Virtual Partitions Behave Differently on Errors"
 
     This behavior is different in the case of Virtual Partitions. Please refer to [this Wiki section](Pro-Consumer-Groups-Virtual-Partitions#behaviour-on-errors) for more details.
 

--- a/Consumer-Groups/Pausing-Seeking-and-Rate-Limiting.md
+++ b/Consumer-Groups/Pausing-Seeking-and-Rate-Limiting.md
@@ -28,7 +28,7 @@ def consume
 end
 ```
 
-!!! note "Note"
+!!! note "#pause Does Not Stop Processing Flow"
 
     It is important to remember that the `#pause` invocation does **not** stop the processing flow. You need to do it yourself.
 

--- a/Consumer-Groups/Pausing-Seeking-and-Rate-Limiting.md
+++ b/Consumer-Groups/Pausing-Seeking-and-Rate-Limiting.md
@@ -28,7 +28,7 @@ def consume
 end
 ```
 
-!!! note "#pause Does Not Stop Processing Flow"
+!!! note "`#pause` Does Not Stop Processing Flow"
 
     It is important to remember that the `#pause` invocation does **not** stop the processing flow. You need to do it yourself.
 

--- a/Consumer-Groups/Routing.md
+++ b/Consumer-Groups/Routing.md
@@ -9,7 +9,7 @@ Karafka uses consumer groups to subscribe to topics. Each consumer group needs t
 - settings level - root settings that will be used everywhere
 - topic level - options that need to be set on a per topic level or overrides to options set on a root level
 
-!!! note "Note"
+!!! note "Most Settings Are Optional With Defaults"
 
     Most of the settings (apart from the ```consumer```) are optional and if not configured, will use defaults provided during the [configuration](https://github.com/karafka/karafka/wiki/Basics-Configuration) of the app itself.
 

--- a/Development/Technical-Writing.md
+++ b/Development/Technical-Writing.md
@@ -4,7 +4,7 @@ Karafka documentation follows a controlled writing style we call Karafka Simplif
 
 Treat this as a clarity floor, not a straitjacket. Apply the rules hardest to procedures, reference, and instructions. Keep conceptual and overview pages readable, and prefer clarity over a rigid rule when the two ever conflict. Promotional and marketing passages (for example the Pro upsell blocks) sit outside what STE was designed for - apply it loosely there, or exclude those blocks from enforcement.
 
-!!! info "Scope"
+!!! info "Applies to Hand-Authored Prose Only"
 
     This style applies to hand-authored prose only. Do **not** edit the auto-generated files - component changelogs, the generated `Librdkafka` references (`Changelog`, `Errors`, `Statistics`, `Configuration`), instrumentation events, and the integration tests catalog - they regenerate from upstream. Everything else, including the hand-authored `Librdkafka/Threads-and-Pipe-Patterns.md`, is in scope.
 

--- a/Infrastructure/AWS-MSK-Guide.md
+++ b/Infrastructure/AWS-MSK-Guide.md
@@ -207,7 +207,7 @@ Receive failed: Disconnected (after 600Xms in state UP)
 
 The broker sends a TCP FIN; librdkafka detects it promptly on the next read and reconnects. Because the broker only reaps after `connections.max.idle.ms` of genuine inactivity, there are no in-flight ProduceRequests at reap time - nothing to drop.
 
-!!! note "msg_timed_out Means Unconfirmed, Not Necessarily Lost"
+!!! note "`msg_timed_out` Means Unconfirmed, Not Necessarily Lost"
 
     When a ProduceRequest times out, the broker may have already written the message to the log before the client gave up waiting for the acknowledgment. The actual delivery status is **POSSIBLY_PERSISTED** - the message is unconfirmed, not guaranteed lost. For non-idempotent producers, this creates genuine ambiguity between data loss and duplication. Use idempotent or transactional producers when exactly-once delivery semantics are required.
 

--- a/Infrastructure/Admin/API.md
+++ b/Infrastructure/Admin/API.md
@@ -212,7 +212,7 @@ By using the `read_topic` method, you can read data from a given topic partition
 
     While the returned messages are `Karafka::Messages::Message` objects, they may not hold the correct notion of the topic details unless the given topic is defined in Karafka routes. For topics that are not defined, defaults will be used.
 
-!!! note "read_topic Skips Compacted and Transaction Offsets"
+!!! note "`read_topic` Skips Compacted and Transaction Offsets"
 
     When using the `#read_topic` method in the Karafka Admin API to retrieve messages from a topic partition, it's essential to understand that this method skips offsets of compacted messages and transactions-related messages. This means that these specific messages won't be fetched or displayed even if they exist in the topic partition. However, while these messages are skipped during retrieval, they are still included in the total counts for those in that partition.
 

--- a/Infrastructure/Admin/API.md
+++ b/Infrastructure/Admin/API.md
@@ -208,11 +208,11 @@ puts info.topics.map { |topic| topic[:topic_name] }.join(', ')
 
 By using the `read_topic` method, you can read data from a given topic partition without subscribing to it.
 
-!!! note "Note"
+!!! note "Topic Details Require Defined Routes"
 
     While the returned messages are `Karafka::Messages::Message` objects, they may not hold the correct notion of the topic details unless the given topic is defined in Karafka routes. For topics that are not defined, defaults will be used.
 
-!!! note "Note"
+!!! note "read_topic Skips Compacted and Transaction Offsets"
 
     When using the `#read_topic` method in the Karafka Admin API to retrieve messages from a topic partition, it's essential to understand that this method skips offsets of compacted messages and transactions-related messages. This means that these specific messages won't be fetched or displayed even if they exist in the topic partition. However, while these messages are skipped during retrieval, they are still included in the total counts for those in that partition.
 

--- a/Infrastructure/Declarative-Topics.md
+++ b/Infrastructure/Declarative-Topics.md
@@ -135,7 +135,7 @@ end
 
 This will effectively ignore this topic from being altered in any way by Karafka. Karafka will ignore this topic together in all the CLI topics related operations.
 
-!!! note "Note"
+!!! note "Config active Differs From active Method"
 
     Keep in mind that setting `active` to false inside the `#config` is **not** equivalent to disabling the topic consumption using the `active` method.
 

--- a/Infrastructure/Declarative-Topics.md
+++ b/Infrastructure/Declarative-Topics.md
@@ -135,7 +135,7 @@ end
 
 This will effectively ignore this topic from being altered in any way by Karafka. Karafka will ignore this topic together in all the CLI topics related operations.
 
-!!! note "Config active Differs From active Method"
+!!! note "Config `active` Differs From `#active` Method"
 
     Keep in mind that setting `active` to false inside the `#config` is **not** equivalent to disabling the topic consumption using the `active` method.
 

--- a/Infrastructure/Deployment.md
+++ b/Infrastructure/Deployment.md
@@ -369,7 +369,7 @@ To make it work you need to follow few steps:
     heroku kafka:consumer-groups:create CONSUMER_GROUP_NAME
     ```
 
-    !!! note "Kafka Ignores KAFKA_PREFIX When Creating Groups"
+    !!! note "Kafka Ignores `KAFKA_PREFIX` When Creating Groups"
 
         The value of `KAFKA_PREFIX` typically is like `smoothboulder-1234.` which would make the consumer group in Karafka `smoothboulder-1234.app`. Kafka itself does not need to know the prefix when creating the consumer group.
 
@@ -438,7 +438,7 @@ To make it work you need to follow few steps:
     heroku kafka:consumer-groups:create karafka-web-ui
     ```
 
-    !!! note "Create Topics Without the KAFKA_PREFIX"
+    !!! note "Create Topics Without the `KAFKA_PREFIX`"
 
         You will need to configure your topics in Kafka before they can be used. This can be done in the Heroku UI or via the [CLI](https://devcenter.heroku.com/articles/kafka-on-heroku#managing-kafka) provided by Heroku. Be sure to name your topics _without_ the KAFKA_PREFIX, e.g. `heroku kafka:topics:create users_events --partitions 3`.
 

--- a/Infrastructure/Deployment.md
+++ b/Infrastructure/Deployment.md
@@ -292,7 +292,7 @@ You can also use this ACL command to give all operations access for the brokers 
   --group=*
 ```
 
-!!! note "Note"
+!!! note "Run From a Client With Java and Kafka"
 
     The above command must be run from a client machine with Java + Kafka installation, and the machine should also be able to communicate with the zookeeper nodes.
 
@@ -312,7 +312,7 @@ Details about how Kafka for Heroku works can also be found here:
 
 ### Heroku Kafka Prefix Convention
 
-!!! note "Note"
+!!! note "Applies Only to Multi-Tenant Add-On Mode"
 
     This section **only** applies to the Multi-Tenant add-on mode.
 
@@ -369,7 +369,7 @@ To make it work you need to follow few steps:
     heroku kafka:consumer-groups:create CONSUMER_GROUP_NAME
     ```
 
-    !!! note "Note"
+    !!! note "Kafka Ignores KAFKA_PREFIX When Creating Groups"
 
         The value of `KAFKA_PREFIX` typically is like `smoothboulder-1234.` which would make the consumer group in Karafka `smoothboulder-1234.app`. Kafka itself does not need to know the prefix when creating the consumer group.
 
@@ -438,7 +438,7 @@ To make it work you need to follow few steps:
     heroku kafka:consumer-groups:create karafka-web-ui
     ```
 
-    !!! note "Note"
+    !!! note "Create Topics Without the KAFKA_PREFIX"
 
         You will need to configure your topics in Kafka before they can be used. This can be done in the Heroku UI or via the [CLI](https://devcenter.heroku.com/articles/kafka-on-heroku#managing-kafka) provided by Heroku. Be sure to name your topics _without_ the KAFKA_PREFIX, e.g. `heroku kafka:topics:create users_events --partitions 3`.
 

--- a/Infrastructure/Monitoring-and-Logging.md
+++ b/Infrastructure/Monitoring-and-Logging.md
@@ -20,7 +20,7 @@ A complete list of the supported events can be found [here](https://github.com/k
 
 The best place to hook your listener is at the end of the ```karafka.rb``` file. This will guarantee that your custom listener will be already loaded into memory and visible for the Karafka framework.
 
-!!! note "Note"
+!!! note "Set Up Listeners After Configuring the App"
 
     You should set up listeners **after** configuring the app because Karafka sets up its internal components right after the configuration block. That way, we can be sure everything is loaded and initialized correctly.
 
@@ -212,7 +212,7 @@ Karafka.monitor.notifications_bus.register_event('app.external_api_call')
 
     Operations in statistics event handlers must be fast and non-blocking. In some rdkafka configurations, fibers are used instead of threads for event delivery. This means that a slow or blocking statistics handler will prevent subsequent events from other producers/consumers from being processed, causing delays across your entire application.
 
-!!! note "Note"
+!!! note "Metrics Emit Every 5 Seconds by Default"
 
     Karafka emits metrics every 5 seconds by default, governed by the Kafka setting `statistics.interval.ms`. Metrics are also published during processing and long polling. Whether you are processing data or waiting on more information being shipped from Kafka, metrics publishing will occur.
 
@@ -290,7 +290,7 @@ You can read more about its features [here](Web-UI-Features), and the installati
 
 ## AppSignal Metrics and Error Tracking
 
-!!! tip "Tip"
+!!! tip "Karafka Officially Recommends AppSignal"
     [AppSignal](https://www.appsignal.com/) has had and continues to have, a **tremendous** impact on the Karafka ecosystem. Without their invaluable contributions and support, the progress and evolution of this ecosystem would not have been possible. For those searching for a top-notch monitoring system for Ruby and Rails applications, AppSignal stands out as a prime choice. Karafka officially recommends AppSignal as the supported integration for its community and users.
 
 Karafka's integration with [AppSignal](https://www.appsignal.com/) offers comprehensive support for error reporting and performance monitoring, making it a seamless solution for monitoring your Kafka-based applications.
@@ -309,7 +309,7 @@ Key Metrics Include:
 
 By using the Karafka AppSignal integration, you can proactively manage your Kafka-based applications, ensuring they operate smoothly and reliably.
 
-!!! note "Note"
+!!! note "Subscribe to Error Listener Before Metrics"
 
     When setting up listeners for both metrics and errors, it's **crucial** to subscribe to the error listener first and then the metrics listener. Doing so in reverse may result in incorrect propagation of namespace and transaction details, leading to potential data inconsistencies. Ensure the correct sequence for accurate monitoring and data integrity.
 
@@ -597,7 +597,7 @@ Karafka.monitor.subscribe(dd_logger_listener) if %w[staging production].include?
 
 ![Example Karafka DD dashboard](https://karafka.io/assets/misc/printscreens/karafka_dd_tracing.png)
 
-!!! note "Note"
+!!! note "Tracing Contributed by Bruno Martins"
 
     Tracing capabilities were added by [Bruno Martins](https://github.com/bruno-b-martins).
 
@@ -698,7 +698,7 @@ Kubernetes is an open-source platform for automating the deployment and manageme
 
 ## OpenTelemetry
 
-!!! note "Note"
+!!! note "WaterDrop Needs Its Own Instrumentation Layer"
 
     WaterDrop has a separate instrumentation layer that you need to enable if you want to monitor both the consumption and production of messages. You can use the same approach as Karafka and WaterDrop share the same core monitoring library.
 
@@ -806,7 +806,7 @@ ActiveSupport::Notifications.subscribe('consumed.consumer.karafka') do |event|
 end
 ```
 
-!!! note "Note"
+!!! note "Each Producer Has Its Own Instrumentation"
 
     Please note that each Karafka producer has its instrumentation instance, so if you use more producers, you need to pipe each of them independently.
 

--- a/Infrastructure/Monitoring-and-Logging.md
+++ b/Infrastructure/Monitoring-and-Logging.md
@@ -597,9 +597,7 @@ Karafka.monitor.subscribe(dd_logger_listener) if %w[staging production].include?
 
 ![Example Karafka DD dashboard](https://karafka.io/assets/misc/printscreens/karafka_dd_tracing.png)
 
-!!! note "Tracing Contributed by Bruno Martins"
-
-    Tracing capabilities were added by [Bruno Martins](https://github.com/bruno-b-martins).
+Tracing capabilities were added by [Bruno Martins](https://github.com/bruno-b-martins).
 
 ##### Async Producer Tracing With The Consumption Context
 
@@ -847,7 +845,7 @@ end
 
 Such a custom monitor will intercept specific events while delegating to the parent monitor to maintain framework functionality. This pattern enables proper error handling, cleanup, and integration with external monitoring systems that require execution to be wrapped in a block.
 
-!!! warning "Avoid Calling super Multiple Times in Custom Monitors"
+!!! warning "Avoid Calling `super` Multiple Times in Custom Monitors"
 
     When overriding Karafka’s instrumentation monitor (`Karafka::Instrumentation::Monitor`), it's crucial **not** to invoke `super` more than once within the `instrument` method. Calling `super` multiple times will cause the original wrapped block of code to execute repeatedly. This can lead to severe and unintended side-effects, such as duplicated message processing, incorrect consumption behaviors, and unexpected logic execution. Always ensure your custom monitor calls `super` exactly once per event, guarding against unintended duplicate invocations.
 

--- a/Infrastructure/Multi-Cluster-Setup.md
+++ b/Infrastructure/Multi-Cluster-Setup.md
@@ -54,7 +54,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-!!! note "Note"
+!!! note "Topics Are Grouped by Target Cluster"
 
     Karafka intelligently groups topics targeting different clusters into distinct subscription groups. This approach optimizes and conserves connections to Kafka, ensuring efficient resource utilization and streamlined data consumption across clusters.
 

--- a/Infrastructure/Signals-and-States.md
+++ b/Infrastructure/Signals-and-States.md
@@ -26,7 +26,7 @@ instrumentation/logger_listener.rb:77:in `on_process_notice_signal'
 ...
 ```
 
-!!! note "Signal Printing Requires LoggerListener"
+!!! note "Signal Printing Needs LoggerListener (On by Default)"
 
     You need to have the `LoggerListener` enabled for this signal to print. It is enabled by default, so this signal should work out of the box unless you altered that.
 

--- a/Infrastructure/Signals-and-States.md
+++ b/Infrastructure/Signals-and-States.md
@@ -26,7 +26,7 @@ instrumentation/logger_listener.rb:77:in `on_process_notice_signal'
 ...
 ```
 
-!!! note "Signal Printing Needs LoggerListener (On by Default)"
+!!! note "Signal Printing Needs `LoggerListener` (On by Default)"
 
     You need to have the `LoggerListener` enabled for this signal to print. It is enabled by default, so this signal should work out of the box unless you altered that.
 
@@ -38,7 +38,7 @@ Using `TSTP` allows you to gracefully finish all the work and shut down without 
 
 Use `TSTP` + `TERM` to guarantee shut down within a period. The best practice is sending `TSTP` at the start of deployment and `TERM` at the end.
 
-!!! note "TSTP Still Requires TERM to Exit"
+!!! note "`TSTP` Still Requires `TERM` to Exit"
 
     You still need to send `TERM` to exit the Karafka process.
 

--- a/Infrastructure/Signals-and-States.md
+++ b/Infrastructure/Signals-and-States.md
@@ -26,7 +26,7 @@ instrumentation/logger_listener.rb:77:in `on_process_notice_signal'
 ...
 ```
 
-!!! note "Note"
+!!! note "Signal Printing Requires LoggerListener"
 
     You need to have the `LoggerListener` enabled for this signal to print. It is enabled by default, so this signal should work out of the box unless you altered that.
 
@@ -38,7 +38,7 @@ Using `TSTP` allows you to gracefully finish all the work and shut down without 
 
 Use `TSTP` + `TERM` to guarantee shut down within a period. The best practice is sending `TSTP` at the start of deployment and `TERM` at the end.
 
-!!! note "Note"
+!!! note "TSTP Still Requires TERM to Exit"
 
     You still need to send `TERM` to exit the Karafka process.
 

--- a/Kafka/Best-Practices.md
+++ b/Kafka/Best-Practices.md
@@ -34,7 +34,7 @@ Pick a count with many divisors (6, 12, 24, 60) to give yourself flexible consum
 
 Messages are only ordered within a partition; cross-partition ordering is never guaranteed. The tradeoffs: too few partitions limit parallelism, while too many increase end-to-end latency (roughly 20ms per 1,000 partitions replicated), create more file handles, and extend broker recovery time.
 
-!!! warning "Warning"
+!!! warning "Stay Under 4,000 Partitions Per Broker"
 
     Stay under 4,000 partitions per broker. Beyond this, you'll see degraded performance and longer recovery times.
 
@@ -168,7 +168,7 @@ Use past tense for events (`created`, `updated`) and imperative for commands (`p
 
 Pick one separator style and stick with it. Mixing periods and underscores causes metric name collisions in monitoring systems. Avoid including fields that change, like team names or service owners.
 
-!!! warning "Warning"
+!!! warning "Consumer Group Names Must Be Globally Unique"
 
     Consumer group names must be globally unique within the cluster. Ensure your naming scheme prevents collisions between environments if they share a cluster.
 

--- a/Kafka/Best-Practices.md
+++ b/Kafka/Best-Practices.md
@@ -168,7 +168,7 @@ Use past tense for events (`created`, `updated`) and imperative for commands (`p
 
 Pick one separator style and stick with it. Mixing periods and underscores causes metric name collisions in monitoring systems. Avoid including fields that change, like team names or service owners.
 
-!!! warning "Consumer Group Names Must Be Globally Unique"
+!!! warning "Consumer Group Names Must Be Unique Per Cluster"
 
     Consumer group names must be globally unique within the cluster. Ensure your naming scheme prevents collisions between environments if they share a cluster.
 

--- a/Kafka/New-Rebalance-Protocol.md
+++ b/Kafka/New-Rebalance-Protocol.md
@@ -149,7 +149,7 @@ KIP-848 supports live migration without downtime. When the first consumer using 
     - Continue restarting remaining consumers one at a time
     - Monitor for any errors during the rollout
 
-    !!! warning "Warning"
+    !!! warning "Complete Migration Within a Few Hours"
 
         Complete the migration within a few hours. Don't leave the group in a mixed state for extended periods.
 

--- a/Pro/Consumer-Groups/Delayed-Topics.md
+++ b/Pro/Consumer-Groups/Delayed-Topics.md
@@ -34,7 +34,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-!!! note "Note"
+!!! note "Delay Time Is Specified in Milliseconds"
 
     Please keep in mind, that the delay time needs to be provided in milliseconds
 

--- a/Pro/Consumer-Groups/Enhanced-Active-Job.md
+++ b/Pro/Consumer-Groups/Enhanced-Active-Job.md
@@ -264,7 +264,7 @@ When using the ActiveJob adapter with Virtual Partitions, upon any error in any 
 
 For non-VP setup, same error behaviors apply as for standard [Active Job adapter](Consumer-Groups-Active-Job#behaviour-on-errors).
 
-!!! note "Note"
+!!! note "Virtual Partitions Mark Jobs Only After All Finish"
 
     Please keep in mind that if you use it in combination with [Virtual Partitions](Pro-Consumer-Groups-Virtual-Partitions), marking jobs as consumed (done) will happen only **after** all virtually partitioned consumers finished their work collectively. There is **no** intermediate marking in between jobs in that scenario.
 

--- a/Pro/Consumer-Groups/Enhanced-Dead-Letter-Queue.md
+++ b/Pro/Consumer-Groups/Enhanced-Dead-Letter-Queue.md
@@ -89,7 +89,7 @@ Enhanced Dead Letter Queue ensures that messages moved to the DLQ topic will alw
   </small>
 </p>
 
-!!! note "Note"
+!!! note "DLQ Partition Count Need Not Match Source"
 
     The DLQ topic does not have to have the same number of partitions as the topics from which the broken messages come. Karafka will ensure that all the messages from the same origin partition will end up in the same DLQ topic partition.
 
@@ -177,7 +177,7 @@ class MyConsumer
 end
 ```
 
-!!! note "Note"
+!!! note "No Routing Changes Required"
 
     No routing changes are needed to make it work.
 

--- a/Pro/Consumer-Groups/Filtering-API.md
+++ b/Pro/Consumer-Groups/Filtering-API.md
@@ -85,7 +85,7 @@ For example, in case you want to pause the processing, you need to return the fo
 - number of milliseconds to pause under `#timeout`.
 - message containing the desired offset from which to start processing after un-pausing under `#cursor`.
 
-!!! note "Note"
+!!! note "User Actions Take Precedence Over Filters"
 
     User actions always take precedence over Filtering API automatic actions. This means that even if you issue a `:pause` action request, in case of a user manual pause, it will be applied and not the filter one. Same applies to the `:seek` logic.
 

--- a/Pro/Consumer-Groups/Long-Running-Jobs.md
+++ b/Pro/Consumer-Groups/Long-Running-Jobs.md
@@ -79,7 +79,7 @@ Upon a group rebalance, there are three scenarios affecting the paused partition
 2. Partition is revoked and re-assigned to the same process.
 3. Partition is revoked and assigned to a different process.
 
-!!! note "revoked? Updates Even When Workers Are Busy"
+!!! note "`#revoked?` Updates Even When Workers Are Busy"
 
     The `#revoked?` method value changes independently from the workers' occupation. This means that the revocation status will be updated even if all the workers are busy processing long-running jobs.
 

--- a/Pro/Consumer-Groups/Long-Running-Jobs.md
+++ b/Pro/Consumer-Groups/Long-Running-Jobs.md
@@ -79,11 +79,11 @@ Upon a group rebalance, there are three scenarios affecting the paused partition
 2. Partition is revoked and re-assigned to the same process.
 3. Partition is revoked and assigned to a different process.
 
-!!! note "Note"
+!!! note "revoked? Updates Even When Workers Are Busy"
 
     The `#revoked?` method value changes independently from the workers' occupation. This means that the revocation status will be updated even if all the workers are busy processing long-running jobs.
 
-!!! note "Note"
+!!! note "Revocation Jobs Do Not Block Polling"
 
     Revocation jobs are also non-blocking for long-running jobs. If the internal workers' batch is full, they will not block polling.
 

--- a/Pro/Consumer-Groups/Scheduling-API.md
+++ b/Pro/Consumer-Groups/Scheduling-API.md
@@ -321,7 +321,7 @@ This approach ensures that the system remains efficient and responsive to its op
 
 ## Expired Jobs Scheduling
 
-!!! note "Every Job Must Be Scheduled"
+!!! note "Schedule Every Job Except During Recovery"
 
     In Karafka, all jobs given to the scheduler must be scheduled, even if they seem redundant. This is essential for maintaining system integrity and efficiency. The only exception is for accumulated jobs of a subscription group under recovery.
 

--- a/Pro/Consumer-Groups/Scheduling-API.md
+++ b/Pro/Consumer-Groups/Scheduling-API.md
@@ -92,7 +92,7 @@ In contrast, a stateless scheduler does not retain state information from one ta
 
 ### API Methods
 
-!!! note "Each Method Has a Non-Blocking on_ Counterpart"
+!!! note "Each Method Has a Non-Blocking `on_` Counterpart"
 
     Please note that each method described in the following section has a non-blocking counterpart. These are easily identifiable by their `on_` prefix. For instance, for the method named `manage`, its non-blocking equivalent is `on_manage`.
 

--- a/Pro/Consumer-Groups/Scheduling-API.md
+++ b/Pro/Consumer-Groups/Scheduling-API.md
@@ -92,7 +92,7 @@ In contrast, a stateless scheduler does not retain state information from one ta
 
 ### API Methods
 
-!!! note "Note"
+!!! note "Each Method Has a Non-Blocking on_ Counterpart"
 
     Please note that each method described in the following section has a non-blocking counterpart. These are easily identifiable by their `on_` prefix. For instance, for the method named `manage`, its non-blocking equivalent is `on_manage`.
 
@@ -227,7 +227,7 @@ end
 
 ### Example Custom Scheduler
 
-!!! note "Note"
+!!! note "Study Default Schedulers for Real Examples"
 
     Besides viewing the example scheduler below, we encourage you to check Karafka's default schedulers in the Karafka sources for more real-life examples.
 
@@ -321,7 +321,7 @@ This approach ensures that the system remains efficient and responsive to its op
 
 ## Expired Jobs Scheduling
 
-!!! note "Note"
+!!! note "Every Job Must Be Scheduled"
 
     In Karafka, all jobs given to the scheduler must be scheduled, even if they seem redundant. This is essential for maintaining system integrity and efficiency. The only exception is for accumulated jobs of a subscription group under recovery.
 

--- a/Pro/Messages-At-Rest-Encryption.md
+++ b/Pro/Messages-At-Rest-Encryption.md
@@ -32,7 +32,7 @@ Once everything is configured, Karafka will automatically produce encrypted mess
 
 Karafka keeps messages encrypted until their deserialization.
 
-!!! note "Note"
+!!! note "Only Payloads Are Encrypted, Not Keys or Headers"
 
     Karafka encrypts **only** the message payload. All other things are cleartext to aid with debugging. Do not store any sensitive information in message keys or headers.
 
@@ -109,7 +109,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-!!! note "Note"
+!!! note "Use This Pattern Only With Trusted Entities"
 
     Such a pattern should only be used when working with trusted entities.
 

--- a/Pro/Security.md
+++ b/Pro/Security.md
@@ -22,7 +22,7 @@ On top of that, to ensure the stability and security of the system:
 - Karafka Pro provides [script](Pro-Getting-Started#license-gem-integrity-verification) you can include in your CI/CD pipeline to ensure license integrity.
 - Every release of every Karafka component is announced on our [Slack](https://slack.karafka.io).
 
-!!! note "Note"
+!!! note "Bundling the License Requires an Enterprise Agreement"
 
     If your organization policy prevents using **any** external dependency sources, a Karafka Pro license can be bundled into your application. This, however, requires a separate [Enterprise](Pro-Enterprise) agreement with us. Please [contact us](https://karafka.io#support) for more details.
 

--- a/Pro/Support.md
+++ b/Pro/Support.md
@@ -52,6 +52,6 @@ We recognize the significance of prompt and effective bug resolution for your on
 
 By opting for Karafka Pro, you are not just purchasing a product but partnering with people committed to ensuring the smooth operation of your applications.
 
-!!! note "Note"
+!!! note "Software Is Provided As Is; Test During Trial"
 
     Please note that our software is provided "as is." We recommend using the trial period to thoroughly test it, as we cannot guarantee it will be entirely bug-free or that all issues will be resolved. That said, we always strive to deliver the best, and historically, there have been no unresolved bugs. However, given Kafka's complexity, situations can vary.

--- a/Pro/Web-UI/Commanding.md
+++ b/Pro/Web-UI/Commanding.md
@@ -38,7 +38,7 @@ Opting out of commanding is recommended for environments where direct consumer m
 
 The commanding functionality within the Web UI is organized into two distinct tabs: "Controls" and "Commands." These tabs provide a centralized interface for managing consumer processes, making it easier for administrators to perform and track administrative actions directly from the Web UI.
 
-!!! info "Info"
+!!! info "Commands Are Retained in Kafka for 7 Days"
 
     Commands issued through the Web UI are retained in Kafka for a default period of 7 days. After this duration, these commands are automatically removed from the system. This automatic cleanup helps manage the storage and maintain efficiency within Kafka without manual intervention.
 

--- a/Pro/Web-UI/Commanding.md
+++ b/Pro/Web-UI/Commanding.md
@@ -38,7 +38,7 @@ Opting out of commanding is recommended for environments where direct consumer m
 
 The commanding functionality within the Web UI is organized into two distinct tabs: "Controls" and "Commands." These tabs provide a centralized interface for managing consumer processes, making it easier for administrators to perform and track administrative actions directly from the Web UI.
 
-!!! info "Commands Are Retained in Kafka for 7 Days"
+!!! info "Commands Are Retained for 7 Days by Default"
 
     Commands issued through the Web UI are retained in Kafka for a default period of 7 days. After this duration, these commands are automatically removed from the system. This automatic cleanup helps manage the storage and maintain efficiency within Kafka without manual intervention.
 

--- a/Upgrades/Karafka/2.0.md
+++ b/Upgrades/Karafka/2.0.md
@@ -314,7 +314,7 @@ To mitigate this you need to:
 
 ## Topic mappers are no longer supported
 
-!!! note "Note"
+!!! note "Skip This Section Unless You Used Heroku"
 
     Unless you used Heroku, you can probably skip this section.
 

--- a/Upgrades/Versions-Lifecycle-and-EOL.md
+++ b/Upgrades/Versions-Lifecycle-and-EOL.md
@@ -64,7 +64,7 @@ Karafka and its components versions or release series are categorized below into
 
 We officially provide support for all the versions of Ruby that are not EOL, and we align with their EOL schedule.
 
-!!! note "Note"
+!!! note "Older Ruby May Work but Is Unsupported"
 
     If you are using an older Ruby version, Karafka may still work. The EOL table indicates versions we officially test and support.
 

--- a/WaterDrop/Configuration.md
+++ b/WaterDrop/Configuration.md
@@ -57,7 +57,7 @@ Some of the options are:
 | `instrument_on_wait_queue_full`             | Should we instrument when `queue_full` occurs                                  |
 | `statistics_decorator`                      | Custom decorator for controlling which statistics keys get `_d`/`_fd` deltas   |
 
-!!! info "Info"
+!!! info "Full List of Root Configuration Options"
 
     Full list of the root configuration options is available [here](https://github.com/karafka/waterdrop/blob/master/lib/waterdrop/config.rb#L25).
 
@@ -338,7 +338,7 @@ Below you can find examples where each of the validations layers fails:
     #     Broker: Message size too large (msg_size_too_large)> (WaterDrop::Errors::ProduceError)
     ```
 
-!!! note "Note"
+!!! note "msg_size_too_large Has Two Indistinguishable Causes"
 
     The `msg_size_too_large error` can arise from:
 

--- a/WaterDrop/Configuration.md
+++ b/WaterDrop/Configuration.md
@@ -338,7 +338,7 @@ Below you can find examples where each of the validations layers fails:
     #     Broker: Message size too large (msg_size_too_large)> (WaterDrop::Errors::ProduceError)
     ```
 
-!!! note "msg_size_too_large Has Two Indistinguishable Causes"
+!!! note "`msg_size_too_large` Has Two Indistinguishable Causes"
 
     The `msg_size_too_large error` can arise from:
 

--- a/WaterDrop/Error-Handling.md
+++ b/WaterDrop/Error-Handling.md
@@ -1,6 +1,6 @@
 Understanding WaterDrop error handling mechanisms is crucial for developing robust and reliable Kafka-based applications.
 
-!!! note "Note"
+!!! note "Covers the Standard Producer, Not Transactional"
 
     This document focuses on error handling for the Standard Producer (non-transactional). For information regarding the error behavior of the Transactional Producer, it is highly recommended to refer to the [Transactional Producer](WaterDrop-Transactions) documentation.
 

--- a/WaterDrop/Getting-Started.md
+++ b/WaterDrop/Getting-Started.md
@@ -1,6 +1,6 @@
 # Getting Started with WaterDrop
 
-!!! info "Info"
+!!! info "Use Karafka to Both Produce and Consume"
 
     If you want to both produce and consume messages, please use [Karafka](Basics-Getting-Started). It integrates WaterDrop automatically.
 
@@ -50,7 +50,7 @@ To get started with WaterDrop:
     )
     ```
 
-!!! info "Info"
+!!! info "More Examples in the Usage Section"
 
     For additional WaterDrop usage examples, please refer to the [Usage](WaterDrop-Usage) section of this documentation.
 

--- a/WaterDrop/Monitoring-and-Logging.md
+++ b/WaterDrop/Monitoring-and-Logging.md
@@ -22,7 +22,7 @@ producer.produce_async(topic: 'events', payload: 'data')
 producer.close
 ```
 
-!!! info "See EVENTS for All Supported Events"
+!!! info "See `EVENTS` for All Supported Events"
 
     See the `WaterDrop::Instrumentation::Notifications::EVENTS` for the list of all the supported events.
 
@@ -274,11 +274,11 @@ end
 # WaterDrop error occurred: Local: Broker transport failure (transport)
 ```
 
-!!! note "error.occurred Includes Synchronous librdkafka Errors"
+!!! note "`error.occurred` Includes Synchronous librdkafka Errors"
 
     `error.occurred` will also include any errors originating from `librdkafka` for synchronous operations, including those that are raised back to the end user.
 
-!!! note "error.occurred Excludes Transaction Purge Errors"
+!!! note "`error.occurred` Excludes Transaction Purge Errors"
 
     The `error.occurred` will **not** publish purge errors originating from transactions. Such occurrences are standard behavior during an aborted transaction and should not be classified as errors. For a deeper understanding, please consult the [transactions](WaterDrop-Transactions) documentation.
 

--- a/WaterDrop/Monitoring-and-Logging.md
+++ b/WaterDrop/Monitoring-and-Logging.md
@@ -22,7 +22,7 @@ producer.produce_async(topic: 'events', payload: 'data')
 producer.close
 ```
 
-!!! info "Info"
+!!! info "See EVENTS for All Supported Events"
 
     See the `WaterDrop::Instrumentation::Notifications::EVENTS` for the list of all the supported events.
 
@@ -172,7 +172,7 @@ WaterDrop is configured to emit internal `librdkafka` metrics every five seconds
 
 The statistics include all of the metrics from `librdkafka` (complete list [here](Librdkafka-Statistics)) as well as the diff of those against the previously emitted values.
 
-!!! note "Note"
+!!! note "Metrics Mix Milliseconds and Microseconds"
 
     In the WaterDrop statistics metrics, specific measurements are denoted in milliseconds, while others are in microseconds. It's imperative to distinguish between these scales, as mistaking one for the other can lead to significant misinterpretations. Always ensure you're referencing the correct unit for each metric to maintain accuracy in your data analysis.
 
@@ -236,7 +236,7 @@ sleep(2)
 producer.close
 ```
 
-!!! note "Note"
+!!! note "Metrics May Be Inconsistent Across Levels"
 
     The metrics returned may not be completely consistent between brokers, toppars and totals, due to the internal asynchronous nature of librdkafka. E.g., the top level tx total may be less than the sum of the broker tx values which it represents.
 
@@ -274,11 +274,11 @@ end
 # WaterDrop error occurred: Local: Broker transport failure (transport)
 ```
 
-!!! note "Note"
+!!! note "error.occurred Includes Synchronous librdkafka Errors"
 
     `error.occurred` will also include any errors originating from `librdkafka` for synchronous operations, including those that are raised back to the end user.
 
-!!! note "Note"
+!!! note "error.occurred Excludes Transaction Purge Errors"
 
     The `error.occurred` will **not** publish purge errors originating from transactions. Such occurrences are standard behavior during an aborted transaction and should not be classified as errors. For a deeper understanding, please consult the [transactions](WaterDrop-Transactions) documentation.
 

--- a/WaterDrop/Testing.md
+++ b/WaterDrop/Testing.md
@@ -1,6 +1,6 @@
 # WaterDrop Testing
 
-!!! note "Note"
+!!! note "Use karafka-testing When Testing With Karafka"
 
     If you're using WaterDrop with Karafka, consider the `karafka-testing` gem for RSpec integration. Detailed documentation on its usage can be found [here](Basics-Testing).
 
@@ -65,7 +65,7 @@ WaterDrop offers a client specifically designed for testing. This client can rep
 
 ### Configuration
 
-!!! note "Note"
+!!! note "karafka-testing Auto-Activates the Buffered Backend"
 
     With the `karafka-testing` gem integrated, the WaterDrop Buffered backend is automatically activated for `Karafka.producer`.
 

--- a/WaterDrop/Testing.md
+++ b/WaterDrop/Testing.md
@@ -1,6 +1,6 @@
 # WaterDrop Testing
 
-!!! note "Use karafka-testing When Testing With Karafka"
+!!! note "Use `karafka-testing` When Testing With Karafka"
 
     If you're using WaterDrop with Karafka, consider the `karafka-testing` gem for RSpec integration. Detailed documentation on its usage can be found [here](Basics-Testing).
 
@@ -65,7 +65,7 @@ WaterDrop offers a client specifically designed for testing. This client can rep
 
 ### Configuration
 
-!!! note "karafka-testing Auto-Activates the Buffered Backend"
+!!! note "`karafka-testing` Auto-Activates the Buffered Backend"
 
     With the `karafka-testing` gem integrated, the WaterDrop Buffered backend is automatically activated for `Karafka.producer`.
 

--- a/Web-UI/Components.md
+++ b/Web-UI/Components.md
@@ -26,6 +26,6 @@ Below you can find the diagram of the whole data flow:
   <img src="https://karafka.io/assets/misc/charts/web-ui-flow.svg" alt="karafka web ui data flow"/>
 </p>
 
-!!! note "Note"
+!!! note "Diagram Is an Abstract Flow"
 
     Please note, that this is an **abstract** flow visualisation. Karafka Web works well even when there is one `karafka server` process running.

--- a/Web-UI/Development-vs-Production.md
+++ b/Web-UI/Development-vs-Production.md
@@ -105,7 +105,7 @@ bundle exec karafka-web install --replication-factor 5
 
 ## Usage with Heroku Kafka Multi-Tenant add-on
 
-!!! note "Note"
+!!! note "Applies Only to Multi-Tenant Add-On Mode"
 
     This section **only** applies to the Multi-Tenant add-on mode.
 

--- a/Web-UI/Features.md
+++ b/Web-UI/Features.md
@@ -98,7 +98,7 @@ The `join_state` field reflects the internal state of the librdkafka consumer gr
 
 ## Jobs
 
-!!! info "Info"
+!!! info "More Metrics in Pro"
 
     More metrics are available in our Pro offering.
 

--- a/Web-UI/Getting-Started.md
+++ b/Web-UI/Getting-Started.md
@@ -247,7 +247,7 @@ If you have the `auto.create.topics.enable` set to `false` or problems running t
 </tbody>
 </table>
 
-!!! note "Note"
+!!! note "Web UI Topics Are Not Declaratively Managed"
 
     Karafka Web UI topics are **not** managed via the [Declarative topics API](Infrastructure-Declarative-Topics). It is done that way, so your destructive infrastructure changes do not break the Web UI. If you want to include their management in your declarative topic's code, you can do so by defining their configuration manually in your routing setup. Injected routing can be found [here](https://github.com/karafka/karafka-web/blob/df679e742aa2988577b084abc3e3a83dd8cff055/lib/karafka/web/installer.rb#L42).
 
@@ -441,7 +441,7 @@ And that is all.
 
 Karafka uses its internal state knowledge and `librdkafka` metrics to report the states. This means that the `statistics.interval.ms` needs to be enabled and should match the reporting interval.
 
-!!! note "Note"
+!!! note "Both Enabled by Default, Reporting Every 5 Seconds"
 
     Both are enabled by default, and both report every 5 seconds, so unless you altered the defaults, you should be good.
 

--- a/Web-UI/Getting-Started.md
+++ b/Web-UI/Getting-Started.md
@@ -247,7 +247,7 @@ If you have the `auto.create.topics.enable` set to `false` or problems running t
 </tbody>
 </table>
 
-!!! note "Web UI Topics Are Not Declaratively Managed"
+!!! note "Web UI Topics Are Not Declaratively Managed by Default"
 
     Karafka Web UI topics are **not** managed via the [Declarative topics API](Infrastructure-Declarative-Topics). It is done that way, so your destructive infrastructure changes do not break the Web UI. If you want to include their management in your declarative topic's code, you can do so by defining their configuration manually in your routing setup. Injected routing can be found [here](https://github.com/karafka/karafka-web/blob/df679e742aa2988577b084abc3e3a83dd8cff055/lib/karafka/web/installer.rb#L42).
 


### PR DESCRIPTION
Replace 84 generic placeholder admonition titles (a bare 'Note'/'Info'/'Warning') with concise Title-Case titles that state each admonition's takeaway, drawn from its body. Enable no-generic-admonition-title so CI keeps new admonitions descriptively titled.

Examples:
- 'Note' -> 'Skipping #close Loses Messages and Leaks Resources'
- 'Warning' -> 'Stay Under 4,000 Partitions Per Broker'
- 'Info' -> 'Commands Are Retained in Kafka for 7 Days'

Title-only changes (84 titles + the config flag); verified no body or other lines changed.