### PR TITLE
docs: de-box redundant callouts; standardize Pro-feature markers

### DIFF
--- a/.rules/no-generic-admonition-title.js
+++ b/.rules/no-generic-admonition-title.js
@@ -9,7 +9,9 @@ const GENERIC_TITLES = new Set([
   'danger', 'success', 'example', 'abstract', 'summary', 'quote', 'question',
   'faq', 'bug', 'failure', 'caution', 'error', 'important', 'important note',
   'please note', 'please read', 'read this', 'read me', 'heads up', 'fyi',
-  'attention', 'notice', 'psa', 'reminder', 'todo', 'to do', 'nb', 'disclaimer'
+  'attention', 'notice', 'psa', 'reminder', 'todo', 'to do', 'nb', 'disclaimer',
+  'pro feature', 'pro only functionality', 'pro only', 'pro enhancements',
+  'karafka pro enhancements', 'enterprise feature', 'enterprise only'
 ]);
 
 function wordCount(text) {

--- a/Infrastructure/CLI.md
+++ b/Infrastructure/CLI.md
@@ -79,9 +79,9 @@ bundle exec karafka server --exclude-topics topic_name2,topic_name5
 
 ## Karafka Topics Health
 
-!!! note "Pro Feature"
+!!! info "`topics health` Is a Pro Command"
 
-    The `topics health` command is a Pro feature available exclusively to Karafka Pro users.
+    The `topics health` command is part of [Karafka Pro](https://karafka.io/#become-pro).
 
 The `topics health` command analyzes your Kafka topics for replication and durability issues. It inspects each topic's replication factor and `min.insync.replicas` setting to detect potential risks, grouping findings by color-coded severity with actionable recommendations.
 

--- a/Infrastructure/Deployment.md
+++ b/Infrastructure/Deployment.md
@@ -312,9 +312,7 @@ Details about how Kafka for Heroku works can also be found here:
 
 ### Heroku Kafka Prefix Convention
 
-!!! note "Applies Only to Multi-Tenant Add-On Mode"
-
-    This section **only** applies to the Multi-Tenant add-on mode.
+This section **only** applies to the Multi-Tenant add-on mode.
 
 All Kafka Basic topics and consumer groups begin with a unique prefix associated with your add-on. This prefix is accessible via the `KAFKA_PREFIX` environment variable.
 

--- a/Pro/Messages-At-Rest-Encryption.md
+++ b/Pro/Messages-At-Rest-Encryption.md
@@ -109,9 +109,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-!!! note "Use This Pattern Only With Trusted Entities"
-
-    Such a pattern should only be used when working with trusted entities.
+Such a pattern should only be used when working with trusted entities.
 
 ## Messages Fingerprinting
 

--- a/Upgrades/Karafka/2.0.md
+++ b/Upgrades/Karafka/2.0.md
@@ -314,9 +314,7 @@ To mitigate this you need to:
 
 ## Topic mappers are no longer supported
 
-!!! note "Skip This Section Unless You Used Heroku"
-
-    Unless you used Heroku, you can probably skip this section.
+Unless you used Heroku, you can probably skip this section.
 
 Topic mapping is no longer supported. Please prefix all of your topic names with the env `KAFKA_PREFIX`.
 

--- a/WaterDrop/Configuration.md
+++ b/WaterDrop/Configuration.md
@@ -57,9 +57,7 @@ Some of the options are:
 | `instrument_on_wait_queue_full`             | Should we instrument when `queue_full` occurs                                  |
 | `statistics_decorator`                      | Custom decorator for controlling which statistics keys get `_d`/`_fd` deltas   |
 
-!!! info "Full List of Root Configuration Options"
-
-    Full list of the root configuration options is available [here](https://github.com/karafka/waterdrop/blob/master/lib/waterdrop/config.rb#L25).
+The full list of the root configuration options is available [here](https://github.com/karafka/waterdrop/blob/master/lib/waterdrop/config.rb#L25).
 
 ## Kafka configuration options
 

--- a/Web-UI/Development-vs-Production.md
+++ b/Web-UI/Development-vs-Production.md
@@ -105,9 +105,7 @@ bundle exec karafka-web install --replication-factor 5
 
 ## Usage with Heroku Kafka Multi-Tenant add-on
 
-!!! note "Applies Only to Multi-Tenant Add-On Mode"
-
-    This section **only** applies to the Multi-Tenant add-on mode.
+This section **only** applies to the Multi-Tenant add-on mode.
 
 Please keep in mind that in order for Karafka Web UI to work with Heroku Kafka Multi-Tenant Addon, **all** Karafka Web UI, topics need to be prefixed with your `KAFKA_PREFIX`:
 

--- a/Web-UI/Features.md
+++ b/Web-UI/Features.md
@@ -4,9 +4,9 @@ Karafka Web UI contains several features allowing you to understand your system'
 
 Below you can find a comprehensive description of the most important features you can use.
 
-!!! info "Karafka Pro Enhancements"
+!!! info "Web UI Enhancements in Karafka Pro"
 
-    Karafka Pro offers enhanced Web UI with many additional metrics and functionalities.
+    [Karafka Pro](https://karafka.io/#become-pro) adds many additional Web UI metrics and functionalities.
 
 !!! tip "Web UI Scope and Simplifications"
 
@@ -14,9 +14,9 @@ Below you can find a comprehensive description of the most important features yo
 
 ## Dashboard
 
-!!! info "Additional Graphs in Pro"
+!!! info "More Dashboard Graphs in Karafka Pro"
 
-    More graphs are available only in our Pro offering.
+    [Karafka Pro](https://karafka.io/#become-pro) adds more graphs to the dashboard.
 
 The dashboard provides an all-encompassing insight into your Karafka operations. It’s an indispensable tool for anyone looking to monitor, optimize, and troubleshoot their Karafka processes. With its user-friendly interface and detailed metrics, you have everything you need to ensure the smooth running of your Kafka operations.
 
@@ -24,9 +24,9 @@ The dashboard provides an all-encompassing insight into your Karafka operations.
 
 ## Consumers
 
-!!! info "Enhanced Consumer Metrics in Pro"
+!!! info "More Consumer Metrics in Karafka Pro"
 
-    More metrics and detailed consumers inspection are available only in our Pro offering.
+    [Karafka Pro](https://karafka.io/#become-pro) adds more consumer metrics and detailed consumer inspection.
 
 The consumers status view allows users to view and monitor the performance of Kafka-running consumers. The page displays real-time data and aggregated metrics about the status of the consumers, such as their current offset, lag, the current state of consumers, and others.
 
@@ -98,9 +98,9 @@ The `join_state` field reflects the internal state of the librdkafka consumer gr
 
 ## Jobs
 
-!!! info "More Metrics in Pro"
+!!! info "More Job Metrics in Karafka Pro"
 
-    More metrics are available in our Pro offering.
+    [Karafka Pro](https://karafka.io/#become-pro) adds more metrics to the jobs view.
 
 This page provides a real-time view of the jobs that are currently being processed, including information such as:
 
@@ -138,9 +138,9 @@ The Routing UI view allows users to inspect Karafka's routing configuration, inc
 
 ## Explorer
 
-!!! info "Pro Only Functionality"
+!!! info "Data Explorer Is a Pro Feature"
 
-    This functionality is available only in our Pro offering.
+    The Data Explorer is part of [Karafka Pro](https://karafka.io/#become-pro).
 
 Karafka Data Explorer is an essential tool for users seeking to navigate and comprehend the data produced to Kafka. Offering an intuitive interface and a deep understanding of the routing table, the explorer ensures that users can access deserialized data effortlessly for seamless viewing. You can read more about it [here](Pro-Web-UI#explorer).
 
@@ -150,9 +150,9 @@ Karafka Data Explorer is an essential tool for users seeking to navigate and com
 
 ## Search
 
-!!! info "Pro Only Functionality"
+!!! info "Search Is a Pro Feature"
 
-    This functionality is available only in our Pro offering.
+    The Search feature is part of [Karafka Pro](https://karafka.io/#become-pro).
 
 The Search feature is a tool that enables users to search and filter messages efficiently. This feature allows users to search within one or multiple partitions, start from a specific time or offset, apply custom matchers to payloads, keys, or headers, and use custom deserializers for data.
 
@@ -180,9 +180,9 @@ A Karafka errors page UI view allows users to inspect errors occurring during me
 
 ## DLQ / Dead
 
-!!! info "Pro Only Functionality"
+!!! info "DLQ Dashboard Is a Pro Feature"
 
-    This functionality is available only in our Pro offering.
+    The DLQ dashboard is part of [Karafka Pro](https://karafka.io/#become-pro).
 
 The Dead Letter Queue (DLQ) dashboard allows users to view messages that have failed to be processed and were skipped and moved to the Dead Letter Queue topic with their original details.
 


### PR DESCRIPTION
From the redundancy scan (most callouts were fine - good titles had already resolved it):

- Inline 5 genuinely redundant one-sentence notes whose title just restated the body, into plain prose: Multi-Tenant scope (x2), Heroku-skip, WaterDrop full-config-list link, encryption trusted-entities caveat.
- Standardize 8 inconsistent 'this is Pro' marker callouts (Web-UI/Features.md x7, Infrastructure/CLI.md) to one form: a specific descriptive title naming the feature + a one-line body linking to Karafka Pro, so title and body no longer duplicate. Normalize the CLI marker to 'info'.
- Harden no-generic-admonition-title: add generic Pro/Enterprise placeholder titles ('Pro Feature', 'Pro Only Functionality', ...) to the denylist so the pattern cannot regress.