### PR TITLE
docs: standardize product-name, spelling, and casing terminology

### DIFF
--- a/Basics/Configuration.md
+++ b/Basics/Configuration.md
@@ -184,6 +184,6 @@ These infrastructural settings are crucial for managing Kafka more efficiently. 
 
 - [Getting Started](Basics-Getting-Started) - Initial setup and installation of Karafka for your application
 - [Routing](Consumer-Groups-Routing) - Define how messages from topics are received and consumed
-- [Librdkafka Configuration](Librdkafka-Configuration) - Complete reference of librdkafka configuration options
+- [librdkafka Configuration](Librdkafka-Configuration) - Complete reference of librdkafka configuration options
 - [Multi Cluster Setup](Infrastructure-Multi-Cluster-Setup) - Configure Karafka to work with multiple Kafka clusters
 - [Declarative Topics](Infrastructure-Declarative-Topics) - Manage Kafka topic configurations as code

--- a/Basics/FAQ/Configuration.md
+++ b/Basics/FAQ/Configuration.md
@@ -69,7 +69,7 @@ Visit the [CLI](Infrastructure-CLI) section of our docs to learn more about how 
 
 ## Does Karafka restart dead PG connections?
 
-Karafka will automatically release no longer used ActiveRecord connections. They should be handled and reconnected by the Rails connection reaper. You can implement custom logic to reconnect them yourself if needed beyond the reaping frequency. More details on that can be found [here](Infrastructure-Active-Record-Connections-Management#dealing-with-dead-database-connections).
+Karafka will automatically release no longer used Active Record connections. They should be handled and reconnected by the Rails connection reaper. You can implement custom logic to reconnect them yourself if needed beyond the reaping frequency. More details on that can be found [here](Infrastructure-Active-Record-Connections-Management#dealing-with-dead-database-connections).
 
 ## Does Karafka require gems to be thread-safe?
 

--- a/Basics/FAQ/Producing.md
+++ b/Basics/FAQ/Producing.md
@@ -339,15 +339,15 @@ They are located in the WaterDrop wiki [idempotence section](WaterDrop-Configura
 
 ## Can I use `Karafka.producer` to produce messages that will then be consumed by ActiveJob jobs?
 
-You cannot use `Karafka#producer` to produce messages that will then be consumed by ActiveJob jobs. The reason is that when integrating ActiveJob with Karafka, you should use ActiveJob's scheduling API, specifically `Job.perform_later`, and not the Karafka producer methods.
+You cannot use `Karafka#producer` to produce messages that will then be consumed by Active Job jobs. The reason is that when integrating Active Job with Karafka, you should use Active Job's scheduling API, specifically `Job.perform_later`, and not the Karafka producer methods.
 
-Attempting to use the Karafka producer to send messages for ActiveJob consumption results in mismatches and errors. Karafka's ActiveJob integration has its way of handling messages internally, and how those messages look and what is being sent is abstracted away from the developer. The developer's responsibility is to stick with the ActiveJob APIs.
+Attempting to use the Karafka producer to send messages for Active Job consumption results in mismatches and errors. Karafka's Active Job integration has its way of handling messages internally, and how those messages look and what is being sent is abstracted away from the developer. The developer's responsibility is to stick with the Active Job APIs.
 
-When you want to consume a message produced by an external source, it is not the domain of ActiveJob anymore. That would be regular Karafka consuming, which is different from job scheduling and execution with ActiveJob.
+When you want to consume a message produced by an external source, it is not the domain of Active Job anymore. That would be regular Karafka consuming, which is different from job scheduling and execution with Active Job.
 
 ## Can I use `Karafka.producer` from within ActiveJob jobs running in the karafka server?
 
-**Yes**, any ActiveJob job running in the karafka server can access and use the `Karafka.producer`.
+**Yes**, any Active Job job running in the karafka server can access and use the `Karafka.producer`.
 
 ## Do you recommend using the singleton producer in Karafka for all apps/consumers/jobs in a system?
 

--- a/Basics/Why-Kafka-and-Karafka.md
+++ b/Basics/Why-Kafka-and-Karafka.md
@@ -184,7 +184,7 @@ This closes the gap between Kafka and classic message queues for workloads that 
 
 Karafka is a production-ready Ruby and Rails framework for building Kafka consumers. It handles the operational concerns that would otherwise fall on you: consumer lifecycle management, offset committing, partition rebalancing, multi-threaded processing, error handling, and observability.
 
-WaterDrop, part of the same ecosystem, handles the producer side - publishing messages to Kafka topics from any Ruby process, including Rails controllers, ActiveJob callbacks, and Rake tasks.
+WaterDrop, part of the same ecosystem, handles the producer side - publishing messages to Kafka topics from any Ruby process, including Rails controllers, Active Job callbacks, and Rake tasks.
 
 Karafka Web UI rounds out the picture on the operational side. It is a self-hosted monitoring interface that gives you real-time visibility into consumer group health, partition lag, message throughput, and individual consumer status - all without leaving your browser and without any external dependencies beyond what you already run. When something goes wrong at two in the morning, you will want it.
 

--- a/Consumer-Groups/Active-Job.md
+++ b/Consumer-Groups/Active-Job.md
@@ -63,7 +63,7 @@ end
 
 !!! note "Pro Enhanced Adapter Adds More Features"
 
-    [Pro Enhanced ActiveJob](Pro-Consumer-Groups-Enhanced-Active-Job) adapter supports `Long-Running Jobs`, `Virtual Partitions`, `Ordered Jobs`, `Scheduled Jobs`, and other Pro features.
+    [Pro Enhanced Active Job](Pro-Consumer-Groups-Enhanced-Active-Job) adapter supports `Long-Running Jobs`, `Virtual Partitions`, `Ordered Jobs`, `Scheduled Jobs`, and other Pro features.
 
 ## Usage
 
@@ -127,7 +127,7 @@ Job.perform_all_later(jobs)
 
 ## `karafka_options` Partial Inheritance
 
-When an ActiveJob class defines `karafka_options`, these options are designed to be inherited by any subclass of the job. This inheritance mechanism ensures that all the settings are consistently applied across different jobs, simplifying configuration management and promoting reusability.
+When an Active Job class defines `karafka_options`, these options are designed to be inherited by any subclass of the job. This inheritance mechanism ensures that all the settings are consistently applied across different jobs, simplifying configuration management and promoting reusability.
 
 By default, when a subclass inherits from a parent job class with predefined `karafka_options`, the subclass automatically inherits all of these options. If no explicit `karafka_options` are defined in the subclass, it will use the options set in its parent class.
 
@@ -172,7 +172,7 @@ Please keep in mind that **as long as** the error persists, **no** other jobs fr
 
 ## Usage With the Dead Letter Queue
 
-The Karafka Active Job adapter is fully compatible with the [Dead Letter Queue (DLQ)](Consumer-Groups-Dead-Letter-Queue) feature. Setting the `independent` flag to `true` when configuring DLQ with Active Job is advisable. This recommendation is based on the nature of ActiveJob jobs being inherently independent. The `independent` flag enhances the DLQ's handling of job failures by treating each job separately, aligning with Active Job's operational characteristics.
+The Karafka Active Job adapter is fully compatible with the [Dead Letter Queue (DLQ)](Consumer-Groups-Dead-Letter-Queue) feature. Setting the `independent` flag to `true` when configuring DLQ with Active Job is advisable. This recommendation is based on the nature of Active Job jobs being inherently independent. The `independent` flag enhances the DLQ's handling of job failures by treating each job separately, aligning with Active Job's operational characteristics.
 
 ```ruby
 class KarafkaApp < Karafka::App
@@ -239,19 +239,19 @@ Current.user_id = 1
 Job.perform_later # the job will output "user_id: 1"
 ```
 
-Karafka handles CurrentAttributes by including them as part of the job serialization process before pushing them to Kafka. These attributes are then deserialized by the ActiveJob consumer and set back in your CurrentAttributes classes before executing the job.
+Karafka handles CurrentAttributes by including them as part of the job serialization process before pushing them to Kafka. These attributes are then deserialized by the Active Job consumer and set back in your CurrentAttributes classes before executing the job.
 
 This approach is based on Sidekiq's approach to persisting current attributes: [Sidekiq and Request-Specific Context](https://www.mikeperham.com/2022/07/29/sidekiq-and-request-specific-context/).
 
 ## ActiveJob Continuation
 
-Karafka supports Rails 8.1+ ActiveJob Continuation feature, which allows jobs to pause and resume their execution. This is useful for long-running jobs that need to be broken down into smaller steps, enabling jobs to be interrupted and resumed across application restarts.
+Karafka supports Rails 8.1+ Active Job Continuation feature, which allows jobs to pause and resume their execution. This is useful for long-running jobs that need to be broken down into smaller steps, enabling jobs to be interrupted and resumed across application restarts.
 
 ### Configuration for OSS
 
-In the OSS (Open Source) version of Karafka, ActiveJob Continuation requires specific configuration because delayed resumption is not available without the Pro [Scheduled Messages](Pro-Scheduled-Messages) feature.
+In the OSS (Open Source) version of Karafka, Active Job Continuation requires specific configuration because delayed resumption is not available without the Pro [Scheduled Messages](Pro-Scheduled-Messages) feature.
 
-To use ActiveJob Continuation in OSS Karafka, configure jobs to resume immediately without delay:
+To use Active Job Continuation in OSS Karafka, configure jobs to resume immediately without delay:
 
 ```ruby
 class ProcessImportJob < ActiveJob::Base
@@ -298,12 +298,12 @@ For advanced continuation capabilities including delayed resumes and partitionin
 
 !!! note "OSS and Pro Compatibility"
 
-    ActiveJob Continuation is available in both OSS and Pro versions. The main difference is that OSS requires immediate resumption (`wait: 0`), while Pro supports delayed resumption through the Scheduled Messages feature.
+    Active Job Continuation is available in both OSS and Pro versions. The main difference is that OSS requires immediate resumption (`wait: 0`), while Pro supports delayed resumption through the Scheduled Messages feature.
 
 ## See Also
 
 - [Enhanced Active Job](Pro-Consumer-Groups-Enhanced-Active-Job) - Advanced features including long-running jobs, virtual partitions, and ordered jobs
-- [Testing](Basics-Testing) - Test your ActiveJob jobs with Karafka's testing helpers
+- [Testing](Basics-Testing) - Test your Active Job jobs with Karafka's testing helpers
 - [Dead Letter Queue](Consumer-Groups-Dead-Letter-Queue) - Handle failed jobs using DLQ with independent mode
 - [Long Running Jobs](Pro-Consumer-Groups-Long-Running-Jobs) - Allow jobs to run longer than max.poll.interval.ms
 - [Error Handling and Back Off Policy](Consumer-Groups-Error-Handling-and-Back-Off-Policy) - Understand error handling and retry behavior for jobs

--- a/Consumer-Groups/Unexpected-Message-Reprocessing.md
+++ b/Consumer-Groups/Unexpected-Message-Reprocessing.md
@@ -66,7 +66,7 @@ Consider a batch where message 4 fails three times before succeeding, and messag
 
 The same counter accumulation can, in certain patterns, cause individual messages to be retried fewer times than expected rather than more, depending on which messages fail and in which order.
 
-The following configuration will exhibit this behaviour. With a shared counter, message 7 "inherits" the retries already spent on message 4 and hits the DLQ after fewer attempts than `max_retries` would suggest:
+The following configuration will exhibit this behavior. With a shared counter, message 7 "inherits" the retries already spent on message 4 and hits the DLQ after fewer attempts than `max_retries` would suggest:
 
 ```ruby
 class KarafkaApp < Karafka::App

--- a/Development/Technical-Writing.md
+++ b/Development/Technical-Writing.md
@@ -54,7 +54,7 @@ The rule of thumb: auto-substitute a word only when it is a plain synonym that k
 
 ## Terminology
 
-- Use US English (`behavior`, `initialize`, `cancel`), not UK spelling (`behaviour`, `initialise`).
+- Use US English spelling, never UK: `-ise`/`-yse` endings become `-ize`/`-yze` (`initialize`, `organize`, `optimize`, `optimization`, `customize`, `analyze`), `-our` becomes `-or` (`behavior`, `color`), and `-logue` becomes `-log` (`catalog`). Reserve a UK spelling only inside a code identifier or an external name you do not control.
 - In prose, write product and library names in their human form and reserve the code identifier for backticks: "Active Job" (`ActiveJob` in code), "Active Record" (`ActiveRecord` in code), "OAuth", "Web UI", and always lowercase "librdkafka" (even in links and headings).
 - Use one verb for sending a message: **produce** (it matches the `#produce` API). Do **not** use "dispatch" or "publish" for the same action.
 - `message` is the house term for a Kafka record. Use it consistently; do not switch to "record" or "event" for the same thing.

--- a/Home.md
+++ b/Home.md
@@ -208,7 +208,7 @@
 - [Custom Styling](Pro-Web-UI#custom-styling)
 - [Topics Management](Pro-Web-UI-Topics-Management)
 
-## Librdkafka
+## librdkafka
 
 - [Configuration](Librdkafka-Configuration)
 - [Statistics](Librdkafka-Statistics)

--- a/Infrastructure/Active-Record-Connections-Management.md
+++ b/Infrastructure/Active-Record-Connections-Management.md
@@ -1,14 +1,14 @@
-Karafka interacts with ActiveRecord in the context of database connection management. This integration is designed to ensure efficient resource use and stability during message processing.
+Karafka interacts with Active Record in the context of database connection management. This integration is designed to ensure efficient resource use and stability during message processing.
 
 ## Rails and ActiveRecord Connection Management
 
-Rails, with ActiveRecord, employs a connection pooling mechanism to manage database connections. Connection pooling aims to reuse existing connections, avoiding the overhead of establishing new connections for every database interaction. This mechanism is particularly beneficial in web applications and background job processing, where efficient database connections can significantly impact performance and scalability.
+Rails, with Active Record, employs a connection pooling mechanism to manage database connections. Connection pooling aims to reuse existing connections, avoiding the overhead of establishing new connections for every database interaction. This mechanism is particularly beneficial in web applications and background job processing, where efficient database connections can significantly impact performance and scalability.
 
-In a typical Rails application, ActiveRecord automatically manages database connections. It checks out connections from the pool when needed and returns them after the request or job is completed. However, in the context of background processing frameworks like Karafka, especially when dealing with database replicas, additional steps, as mentioned above, might be necessary to ensure connections are properly managed.
+In a typical Rails application, Active Record automatically manages database connections. It checks out connections from the pool when needed and returns them after the request or job is completed. However, in the context of background processing frameworks like Karafka, especially when dealing with database replicas, additional steps, as mentioned above, might be necessary to ensure connections are properly managed.
 
 ## Automatic Connection Management
 
-When no database replication is involved, Karafka automatically manages ActiveRecord database connections. This means that after processing messages, Karafka releases the connections back to the ActiveRecord connection pool, preventing potential connection leakage and ensuring connections are available for other processes or threads that might need them.
+When no database replication is involved, Karafka automatically manages Active Record database connections. This means that after processing messages, Karafka releases the connections back to the Active Record connection pool, preventing potential connection leakage and ensuring connections are available for other processes or threads that might need them.
 
 ## Dealing with Database Replicas
 
@@ -29,11 +29,11 @@ end
 
 ## Dealing with Dead Database Connections
 
-In production environments, database connections can sometimes become  "dead" or unusable due to various issues like network disruptions,  database restarts, or other unexpected problems. Rails, through ActiveRecord, provides mechanisms to handle such situations, ensuring your application can recover and continue functioning smoothly.
+In production environments, database connections can sometimes become  "dead" or unusable due to various issues like network disruptions,  database restarts, or other unexpected problems. Rails, through Active Record, provides mechanisms to handle such situations, ensuring your application can recover and continue functioning smoothly.
 
-ActiveRecord includes a feature known as the connection "reaper." The reaper periodically checks connections in the pool and removes any dead or idle for too long. This helps maintain a pool of valid connections, but immediate action might be needed when a connection is found dead during a database operation.
+Active Record includes a feature known as the connection "reaper." The reaper periodically checks connections in the pool and removes any dead or idle for too long. This helps maintain a pool of valid connections, but immediate action might be needed when a connection is found dead during a database operation.
 
-ActiveRecord provides the `#verify!` method to handle dead connections dynamically. This method can be called to check if the current connection is still valid. If it is found invalid, `#verify!` will automatically attempt to re-establish it. This method is essential for ensuring that your application can recover from connection issues on the fly.
+Active Record provides the `#verify!` method to handle dead connections dynamically. This method can be called to check if the current connection is still valid. If it is found invalid, `#verify!` will automatically attempt to re-establish it. This method is essential for ensuring that your application can recover from connection issues on the fly.
 
 ### Implementing Immediate Dead Connection Handling
 
@@ -66,7 +66,7 @@ Karafka provides automatic database connection management for standard setups. H
 
 ## See Also
 
-- [Integrating with Ruby on Rails and other frameworks](Infrastructure-Integrating-with-Ruby-on-Rails-and-other-frameworks) - Set up Karafka with Rails and ActiveRecord
+- [Integrating with Ruby on Rails and other frameworks](Infrastructure-Integrating-with-Ruby-on-Rails-and-other-frameworks) - Set up Karafka with Rails and Active Record
 - [Forking](Infrastructure-Forking) - Understand connection handling when using forking and Swarm mode
 - [Concurrency and Multithreading](Consumer-Groups-Concurrency-and-Multithreading) - Manage database connections across threads
 - [Resources Management](Infrastructure-Resources-Management) - Optimize overall resource usage including database connections

--- a/Infrastructure/Admin/Configs-API.md
+++ b/Infrastructure/Admin/Configs-API.md
@@ -138,4 +138,4 @@ Karafka::Admin::Configs.alter(resource)
 ## See Also
 
 - [Admin API](Infrastructure-Admin-API) - General admin operations and topic management
-- [Librdkafka Configuration](Librdkafka-Configuration) - Available librdkafka configuration options
+- [librdkafka Configuration](Librdkafka-Configuration) - Available librdkafka configuration options

--- a/Infrastructure/Debugging.md
+++ b/Infrastructure/Debugging.md
@@ -171,7 +171,7 @@ end
 
 #### External Services not Thread-Safe
 
-Ensure libraries you call (HTTP clients, database drivers, etc.) are thread-safe or use separate connections per thread. For instance, Rails ActiveRecord is thread-safe if you use its connection pooling properly. A gem that is not thread-safe might mishandle requests when called in parallel. This could manifest as duplicate actions. For example, a non-thread-safe cache library might erroneously replay a write operation from two threads.
+Ensure libraries you call (HTTP clients, database drivers, etc.) are thread-safe or use separate connections per thread. For instance, Rails Active Record is thread-safe if you use its connection pooling properly. A gem that is not thread-safe might mishandle requests when called in parallel. This could manifest as duplicate actions. For example, a non-thread-safe cache library might erroneously replay a write operation from two threads.
 
 #### Manual Thread Management in Consumer
 

--- a/Infrastructure/Deployment.md
+++ b/Infrastructure/Deployment.md
@@ -101,7 +101,7 @@ Karafka **does**, however, support:
 - [Standard SASL + SSL mechanisms](#aws-msk-cluster-setup).
 - [Custom OAuth Token Providers](#custom-oauth-token-providers) flow.
 
-Please follow the below instructions for both cluster initialization and Karafka configuration or go to the [Custom Oauth Token Providers](#custom-oauth-token-providers) section.
+Please follow the below instructions for both cluster initialization and Karafka configuration or go to the [Custom OAuth Token Providers](#custom-oauth-token-providers) section.
 
 !!! info "AWS Integration with Custom OAuth Token Providers"
 

--- a/Infrastructure/Env-Variables.md
+++ b/Infrastructure/Env-Variables.md
@@ -1,4 +1,4 @@
-Karafka's behaviour can be altered with the following environment variables:
+Karafka's behavior can be altered with the following environment variables:
 
 <table>
   <thead>

--- a/Infrastructure/Integrating-with-Ruby-on-Rails-and-other-frameworks.md
+++ b/Infrastructure/Integrating-with-Ruby-on-Rails-and-other-frameworks.md
@@ -40,7 +40,7 @@ After that, ensure that your application is loaded before setting up and booting
 
 ## See Also
 
-- [Active Job](Consumer-Groups-Active-Job) - Integrate Karafka with Rails ActiveJob for background processing
+- [Active Job](Consumer-Groups-Active-Job) - Integrate Karafka with Rails Active Job for background processing
 - [Active Record Connections Management](Infrastructure-Active-Record-Connections-Management) - Manage database connections in Karafka consumers
 - [Producing Messages](Basics-Producing-Messages) - Send messages to Kafka from Rails controllers and models
 - [Deployment](Infrastructure-Deployment) - Deploy Karafka alongside Rails applications in production

--- a/Infrastructure/Multi-Cluster-Setup.md
+++ b/Infrastructure/Multi-Cluster-Setup.md
@@ -12,7 +12,7 @@ Karafka is a robust framework that allows applications to interact with multiple
 
     - The `Karafka.producer` will always refer to the primary cluster defined unless overwritten.
 
-    - ActiveJob jobs, when scheduled with Karafka's ActiveJob backend, will also always go to the primary cluster.
+    - Active Job jobs, when scheduled with Karafka's Active Job backend, will also always go to the primary cluster.
 
 4. Admin Operations and Web UI:
 
@@ -97,7 +97,7 @@ SECONDARY_CLUSTER_PRODUCER.produce_sync(
 
 ## Common Mistakes
 
-- **Ignoring Primary Default**: Forgetting that `Karafka.producer` and ActiveJob jobs default to the primary cluster can lead to unexpected routing of messages.
+- **Ignoring Primary Default**: Forgetting that `Karafka.producer` and Active Job jobs default to the primary cluster can lead to unexpected routing of messages.
 
 - **Mismatched Cluster Configuration**: Ensure that all specified clusters in the configuration have the correct broker addresses.
 

--- a/Infrastructure/Resources-Management.md
+++ b/Infrastructure/Resources-Management.md
@@ -151,7 +151,7 @@ puts total #=> 25 000
 
 ## Database Connections Usage
 
-Karafka, by itself, does not manage PostgreSQL or any other database connections directly. When using frameworks like Ruby on Rails, database connections are typically managed by the [ActiveRecord Connection Pool](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html).
+Karafka, by itself, does not manage PostgreSQL or any other database connections directly. When using frameworks like Ruby on Rails, database connections are typically managed by the [Active Record Connection Pool](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html).
 
 Under normal circumstances, Karafka will use the `concurrency` number of database connections at most. This is because, at any given time, that's the maximum number of workers that can run in parallel.
 

--- a/Infrastructure/Swarm-Multi-Process.md
+++ b/Infrastructure/Swarm-Multi-Process.md
@@ -251,7 +251,7 @@ end
 
 Below, you can find a few examples of resources worth preparing and cleaning before forking:
 
-- **Database Connections**: Re-establish database connections to prevent sharing connections between processes, which could lead to locking issues or other concurrency problems. For ActiveRecord, this typically involves calling ActiveRecord::Base.establish_connection.
+- **Database Connections**: Re-establish database connections to prevent sharing connections between processes, which could lead to locking issues or other concurrency problems. For Active Record, this typically involves calling ActiveRecord::Base.establish_connection.
 
 - **Thread Cleanup**: If the preloaded application spawns threads, ensure they are stopped or re-initialized post-fork to avoid sharing thread execution contexts.
 

--- a/Librdkafka/Threads-and-Pipe-Patterns.md
+++ b/Librdkafka/Threads-and-Pipe-Patterns.md
@@ -1,4 +1,4 @@
-# Librdkafka Thread and Pipe Patterns
+# librdkafka Thread and Pipe Patterns
 
 Karafka and WaterDrop rely on librdkafka as the underlying C client for Apache Kafka. librdkafka manages its own native threads and uses pipe file descriptors for internal signaling. Understanding these patterns is essential for capacity planning, debugging resource usage, and diagnosing issues in production environments.
 

--- a/Pro/Consumer-Groups/Enhanced-Active-Job.md
+++ b/Pro/Consumer-Groups/Enhanced-Active-Job.md
@@ -70,7 +70,7 @@ To use the Scheduled Jobs functionality in Karafka, you must:
     end
     ```
 
-1. **Schedule Jobs**: After these configurations are in place, jobs can be scheduled using the standard ActiveJob APIs by specifying the execution time:
+1. **Schedule Jobs**: After these configurations are in place, jobs can be scheduled using the standard Active Job APIs by specifying the execution time:
 
     ```ruby
     ExampleJob.set(wait_until: Date.tomorrow.noon).perform_later(user_id)
@@ -80,11 +80,11 @@ This integration not only simplifies the management of timed tasks but also enha
 
 ## Custom Producer/Variant Usage
 
-When using ActiveJob with Karafka, you can customize the dispatch of Active Jobs by using custom producers or [producer variants](WaterDrop-Variants). This customization allows for more granular control over how jobs are produced and managed within Kafka, which can be crucial for applications with specific performance, scalability, or reliability requirements.
+When using Active Job with Karafka, you can customize the dispatch of Active Jobs by using custom producers or [producer variants](WaterDrop-Variants). This customization allows for more granular control over how jobs are produced and managed within Kafka, which can be crucial for applications with specific performance, scalability, or reliability requirements.
 
-To use a custom producer or variant with ActiveJob, specify a `:producer` option within the `#karafka_options`. This option should be set to a callable object (such as a lambda or a proc) that accepts the job as an argument. This callable is expected to return a producer or a variant that will be used to dispatch the job's message to Kafka.
+To use a custom producer or variant with Active Job, specify a `:producer` option within the `#karafka_options`. This option should be set to a callable object (such as a lambda or a proc) that accepts the job as an argument. This callable is expected to return a producer or a variant that will be used to dispatch the job's message to Kafka.
 
-Here is an example that demonstrates how to integrate a custom producer variant within an ActiveJob setup:
+Here is an example that demonstrates how to integrate a custom producer variant within an Active Job setup:
 
 ```ruby
 # Define a custom producer variant for high-priority jobs
@@ -107,15 +107,15 @@ end
 
 In the above example, `HighPriorityJob` is configured to use a specifically tailored producer variant for critical events. This producer variant is configured with a higher acknowledgment setting (`all`), ensuring that all replicas confirm each message before it is successfully delivered. This setup is particularly beneficial for jobs where data loss or delivery failure is unacceptable.
 
-Allowing each job class to specify its producer offers the flexibility to tailor message production characteristics according to the job's requirements. Whether it's adjusting the acknowledgment levels, managing timeouts, or using specific compression settings, custom producers and variants can significantly enhance the robustness and efficiency of your Karafka-based messaging system within ActiveJob, opening up new possibilities for system optimization and performance improvement.
+Allowing each job class to specify its producer offers the flexibility to tailor message production characteristics according to the job's requirements. Whether it's adjusting the acknowledgment levels, managing timeouts, or using specific compression settings, custom producers and variants can significantly enhance the robustness and efficiency of your Karafka-based messaging system within Active Job, opening up new possibilities for system optimization and performance improvement.
 
 ## Routing Patterns
 
-Pro ActiveJob adapter supports the Routing Patterns capabilities. You can read more about it [here](Pro-Routing-Patterns#activejob-routing-patterns).
+Pro Active Job adapter supports the Routing Patterns capabilities. You can read more about it [here](Pro-Routing-Patterns#activejob-routing-patterns).
 
 ## ActiveJob Continuation
 
-Karafka Pro provides enhanced support for Rails 8.1+ ActiveJob Continuation feature with additional capabilities beyond the OSS version. With Pro, you can use delayed resumption and partitioning within continuation jobs for advanced workflow management.
+Karafka Pro provides enhanced support for Rails 8.1+ Active Job Continuation feature with additional capabilities beyond the OSS version. With Pro, you can use delayed resumption and partitioning within continuation jobs for advanced workflow management.
 
 !!! note "Scheduled Messages Not Required for Immediate Resumption"
 
@@ -125,7 +125,7 @@ Karafka Pro provides enhanced support for Rails 8.1+ ActiveJob Continuation feat
 
 #### Immediate Resumption (No Scheduled Messages Required)
 
-For jobs that need to resume immediately without delays, you can use ActiveJob Continuation without setting up Scheduled Messages:
+For jobs that need to resume immediately without delays, you can use Active Job Continuation without setting up Scheduled Messages:
 
 ```ruby
 class ProcessImportJob < ActiveJob::Base
@@ -240,11 +240,11 @@ This configuration ensures that all continuation steps for a given user are proc
 
 ### Requirements
 
-To use ActiveJob Continuation in Pro with **immediate resumption** (`wait: 0`):
+To use Active Job Continuation in Pro with **immediate resumption** (`wait: 0`):
 
-- No additional setup required beyond the standard ActiveJob adapter configuration
+- No additional setup required beyond the standard Active Job adapter configuration
 
-To use ActiveJob Continuation in Pro with **delayed resumption**:
+To use Active Job Continuation in Pro with **delayed resumption**:
 
 1. **Scheduled Messages Feature**: Must be properly [configured](Pro-Scheduled-Messages#enabling-scheduled-messages)
 2. **Scheduled Messages Topic**: Each job class using delayed resumption must specify `scheduled_messages_topic` in `karafka_options`
@@ -252,7 +252,7 @@ To use ActiveJob Continuation in Pro with **delayed resumption**:
 
 ### OSS Compatibility
 
-For details on using ActiveJob Continuation in the OSS version with immediate resumption, see [ActiveJob Continuation](Consumer-Groups-Active-Job#activejob-continuation).
+For details on using Active Job Continuation in the OSS version with immediate resumption, see [Active Job Continuation](Consumer-Groups-Active-Job#activejob-continuation).
 
 ## Execution Warranties
 
@@ -260,7 +260,7 @@ Same execution warranties apply as for standard [Active Job adapter](Consumer-Gr
 
 ## Behaviour on Errors
 
-When using the ActiveJob adapter with Virtual Partitions, upon any error in any of the Virtual Partitions, all the not-started work in any of the Virtual Partitions will not be executed. The not-executed work will be then executed upon the retry. This behavior minimizes the number of jobs that must be re-processed upon an error.
+When using the Active Job adapter with Virtual Partitions, upon any error in any of the Virtual Partitions, all the not-started work in any of the Virtual Partitions will not be executed. The not-executed work will be then executed upon the retry. This behavior minimizes the number of jobs that must be re-processed upon an error.
 
 For non-VP setup, same error behaviors apply as for standard [Active Job adapter](Consumer-Groups-Active-Job#behaviour-on-errors).
 
@@ -274,7 +274,7 @@ Enhanced Active Job adapter has revocation awareness. That means that Karafka wi
 
 ## Behaviour on Shutdown
 
-When using the ActiveJob adapter with Virtual Partitions, Karafka will **not** early break processing and will continue until all the work is done. This is needed to ensure that all the work is done before committing the offsets.
+When using the Active Job adapter with Virtual Partitions, Karafka will **not** early break processing and will continue until all the work is done. This is needed to ensure that all the work is done before committing the offsets.
 
 For a non-VP setup, the same shutdown behavior applies as for standard [Active Job adapter](Consumer-Groups-Active-Job#behaviour-on-shutdown).
 

--- a/Pro/Consumer-Groups/Parallel-Segments.md
+++ b/Pro/Consumer-Groups/Parallel-Segments.md
@@ -269,7 +269,7 @@ Parallel Segments use a two-step process:
 
 The default reducer is: `->(partition_key) { partition_key.to_s.sum % count }`
 
-This can lead to sub-optimal behaviours where different partition keys map to the same segment.
+This can lead to sub-optimal behaviors where different partition keys map to the same segment.
 
 #### Example of Reducer Collision
 

--- a/Pro/Consumer-Groups/Transactions.md
+++ b/Pro/Consumer-Groups/Transactions.md
@@ -496,7 +496,7 @@ For advanced monitoring or custom integrations, remember that the Karafka consum
 
 !!! tip "`consumer.consuming.transaction` Instrumentation Event"
 
-    The `consumer.consuming.transaction` instrumentation event is triggered after each successful transaction. Importantly, if you raise `WaterDrop::AbortTransaction` to abort a transaction, this event will still be triggered. Similar to how ActiveRecord transactions handle rollbacks internally, the abort, in this case, does not bubble up as an exception. Instead, the transaction is cleanly rolled back, and the event is published, allowing you to track transaction completions even in cases where they were aborted.
+    The `consumer.consuming.transaction` instrumentation event is triggered after each successful transaction. Importantly, if you raise `WaterDrop::AbortTransaction` to abort a transaction, this event will still be triggered. Similar to how Active Record transactions handle rollbacks internally, the abort, in this case, does not bubble up as an exception. Instead, the transaction is cleanly rolled back, and the event is published, allowing you to track transaction completions even in cases where they were aborted.
 
 ## Using Transactions in Swarm Mode
 

--- a/Pro/Enterprise-Architecture-Consultation.md
+++ b/Pro/Enterprise-Architecture-Consultation.md
@@ -57,8 +57,8 @@ Getting the most out of Karafka's Web UI:
 Connecting Karafka with your existing stack:
 
 - **Rails integration** - Proper initialization, connection management, and request/background separation
-- **ActiveJob backend** - When to use Karafka as a job backend vs. dedicated message processing
-- **ActiveRecord connections** - Managing database connection pools with concurrent consumers
+- **Active Job backend** - When to use Karafka as a job backend vs. dedicated message processing
+- **Active Record connections** - Managing database connection pools with concurrent consumers
 - **Testing strategies** - Unit testing consumers, integration testing with Kafka, and CI/CD setup
 - **Monitoring integration** - DataDog, AppSignal, StatsD, and custom instrumentation
 

--- a/Pro/FAQ.md
+++ b/Pro/FAQ.md
@@ -84,7 +84,7 @@ Unlike typical open-source projects that rely on volunteer maintenance, Karafka 
 - Built-in Web UI for monitoring and management
 - Live consumer management (pause/resume partitions in real-time)
 - Comprehensive error handling and Dead Letter Queue functionality
-- Rails integration and ActiveJob backend support
+- Rails integration and Active Job backend support
 - Professional monitoring integrations (AppSignal, StatsD/DataDog)
 
 ### **Long-Term Commitment**

--- a/Pro/Optimized-Statistics-Processing.md
+++ b/Pro/Optimized-Statistics-Processing.md
@@ -78,6 +78,6 @@ The benefits scale with partition count - even at 100+ partitions, the reduced p
 
 ## See Also
 
-- [Librdkafka Statistics](Librdkafka-Statistics) - Reference for all available statistics fields
+- [librdkafka Statistics](Librdkafka-Statistics) - Reference for all available statistics fields
 - [Multiplexing](Pro-Consumer-Groups-Multiplexing) - Multiple connections that compound statistics overhead without this optimization
 - [Web UI](Web-UI-Features) - Benefits from reduced statistics processing overhead

--- a/Pro/Routing-Patterns.md
+++ b/Pro/Routing-Patterns.md
@@ -121,7 +121,7 @@ end
 
 ### ActiveJob Routing Patterns
 
-In the case of ActiveJob, a new method is available called `#active_job_pattern` that allows you to define pattern matchings for ActiveJob jobs. Its API is similar to the `#pattern` one and works the same way:
+In the case of Active Job, a new method is available called `#active_job_pattern` that allows you to define pattern matchings for Active Job jobs. Its API is similar to the `#pattern` one and works the same way:
 
 ```ruby
 class KarafkaApp < Karafka::App

--- a/Pro/Web-UI/Topics-Insights.md
+++ b/Pro/Web-UI/Topics-Insights.md
@@ -83,5 +83,5 @@ In summary, the Distribution Insights feature of the Karafka Pro Web UI is a pow
 
 ## See Also
 
-- [Librdkafka Statistics](Librdkafka-Statistics) - For understanding the underlying statistics that power insights
+- [librdkafka Statistics](Librdkafka-Statistics) - For understanding the underlying statistics that power insights
 - [Pro Topics Management](Pro-Web-UI-Topics-Management) - For managing topic configuration and partitions

--- a/WaterDrop/Configuration.md
+++ b/WaterDrop/Configuration.md
@@ -371,6 +371,6 @@ Understanding the nuances of message size validation is crucial to ensure smooth
 ## See Also
 
 - [WaterDrop Getting Started](WaterDrop-Getting-Started) - Quick start guide for WaterDrop producer
-- [Librdkafka Configuration](Librdkafka-Configuration) - Complete librdkafka configuration reference
+- [librdkafka Configuration](Librdkafka-Configuration) - Complete librdkafka configuration reference
 - [Multi Cluster Setup](Infrastructure-Multi-Cluster-Setup) - Configure and manage multiple Kafka clusters
 - [WaterDrop Variants](WaterDrop-Variants) - Different producer variants and their use cases

--- a/WaterDrop/Transactions.md
+++ b/WaterDrop/Transactions.md
@@ -322,7 +322,7 @@ This behavior may impact you in the following ways:
 
 ## `transactional.id` Management and Fencing
 
-One of the critical aspects of `transactional.id` is its ability to "fence out" older instances of a producer. If a producer instance with a given `transactional.id` crashes and another instance starts with the same `transactional.id`, Kafka ensures that the older producer instance can't commit any more messages, preventing potential duplicates. This behaviour is called fencing.
+One of the critical aspects of `transactional.id` is its ability to "fence out" older instances of a producer. If a producer instance with a given `transactional.id` crashes and another instance starts with the same `transactional.id`, Kafka ensures that the older producer instance can't commit any more messages, preventing potential duplicates. This behavior is called fencing.
 
 Below, you can find an example of how fencing works. After `producer2` first transaction, `producer1` will no longer be able to produce messages and will raise an error:
 
@@ -469,7 +469,7 @@ The reloading mechanism is used exclusively within locked transactions, eliminat
 
 The reloading process will be triggered only by errors caused during message dispatches within transactions. The system reloads on any errors where the cause is `Rdkafka::RdkafkaError`, with specific exclusions to avoid unintended reloading. This approach reloads the client in cases where other errors, such as those from Karafka, occur within transactions. Although this can impact performance due to the overhead of closing and reconnecting, it ensures that all errors result in a rollback, maintaining system integrity.
 
-If you find this behaviour undesired, you have the power to set the `reload_on_transaction_fatal_error` configuration value to `false`. In this case, the producer client will not be reloaded, giving you control over the system's response to fatal errors.
+If you find this behavior undesired, you have the power to set the `reload_on_transaction_fatal_error` configuration value to `false`. In this case, the producer client will not be reloaded, giving you control over the system's response to fatal errors.
 
 ## Aborting Right After Producing
 

--- a/WaterDrop/Variants.md
+++ b/WaterDrop/Variants.md
@@ -112,7 +112,7 @@ Variants allow you to modify several Kafka and producer-specific settings to bet
 
 !!! info "Additional Configuration Attributes Details"
 
-    For a more comprehensive list of configuration settings supported by librdkafka, please visit the [Librdkafka Configuration](Librdkafka-Configuration) page.
+    For a more comprehensive list of configuration settings supported by librdkafka, please visit the [librdkafka Configuration](Librdkafka-Configuration) page.
 
 ## Inspecting the Active Variant
 

--- a/Web-UI/Data-Management.md
+++ b/Web-UI/Data-Management.md
@@ -55,4 +55,4 @@ Karafka Web UI offers a robust, efficient, and reliable solution for monitoring 
 
 - [About Web UI](Web-UI-About) - For an overview of Web UI capabilities
 - [Pro Cleaner API](Pro-Cleaner-API) - For managing and cleaning Web UI data topics
-- [Librdkafka Configuration](Librdkafka-Configuration) - For configuration options that affect Web UI behavior
+- [librdkafka Configuration](Librdkafka-Configuration) - For configuration options that affect Web UI behavior


### PR DESCRIPTION
Align the corpus to the terminology conventions already documented in Development/Technical-Writing.md (lines 57-62). 72 replacements across 29 hand-authored files:

- 'Active Job' / 'Active Record' in prose; ActiveJob/ActiveRecord kept for code (42 + 15)
- always-lowercase 'librdkafka' (9), incl. two case-only headings (anchors unchanged)
- US spelling behaviour->behavior / behaviours->behaviors (5)
- OAuth casing Oauth->OAuth (1)

Applied via a masked substitution pass that skips fenced/inline code, link targets, Ruby namespaces (Foo::Bar), headings for anchor-changing terms, and TOC/nav lines. Verified: npm run lint clean, every link/anchor target byte-identical (nothing in the cross-reference graph moved), no code spans altered, and ./bin/mklint strict MkDocs build passes.