### PR TITLE
docs: tighten prose on high-traffic pages (cut throat-clearing, fille…

### DIFF
--- a/Basics/Configuration.md
+++ b/Basics/Configuration.md
@@ -122,7 +122,7 @@ end
 
 ## Types of Configuration in Karafka
 
-When you work with Karafka, it is crucial to understand the different configurations available, as these settings directly influence how Karafka interacts with your application code and the underlying Kafka infrastructure.
+When you work with Karafka, the different configurations available directly influence how Karafka interacts with your application code and the underlying Kafka infrastructure.
 
 ### Root Configuration in the Setup Block
 

--- a/Basics/FAQ/Configuration.md
+++ b/Basics/FAQ/Configuration.md
@@ -209,7 +209,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-Please note that if your cluster configuration is complex, you may want to use set it up in the root scope and then alter it on a per-topic basis:
+If your cluster configuration is complex, you may want to use set it up in the root scope and then alter it on a per-topic basis:
 
 ```ruby
 class KarafkaApp < Karafka::App
@@ -281,7 +281,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-It is essential to keep in mind that increasing the maximum payload size may impact the performance of your Kafka cluster, so you should carefully consider the trade-offs before making any changes.
+Increasing the maximum payload size may impact the performance of your Kafka cluster, so you should carefully consider the trade-offs before making any changes.
 
 !!! note "Errors From Exceeding `max_payload_size`"
 
@@ -359,9 +359,9 @@ By supporting multiple strategies in the codebase, Karafka can cater to a wide r
 
 **Yes**, you can use Karafka's Admin API to retrieve cluster information and check the reachability of the Kafka cluster. The `Karafka::Admin.cluster_info` method can be used to retrieve metadata about the Kafka cluster, including details about brokers, topics, and partitions.
 
-If the method call is successful, it indicates that the Karafka application was able to connect to the Kafka cluster and retrieve metadata about the brokers and topics. However, it's important to note that this does not necessarily mean everything with the cluster is okay.
+If the method call is successful, it indicates that the Karafka application was able to connect to the Kafka cluster and retrieve metadata about the brokers and topics. However, this does not necessarily mean everything with the cluster is okay.
 
-"Kafka being up" is a rather complex matter. Many factors can affect the overall health and performance of a Kafka cluster, including network issues, broker failures, and misconfigured settings. Therefore, it's essential to use additional monitoring and alerting mechanisms to ensure the reliability and availability of your Kafka cluster.
+"Kafka being up" is a rather complex matter. Many factors can affect the overall health and performance of a Kafka cluster, including network issues, broker failures, and misconfigured settings. Therefore, use additional monitoring and alerting mechanisms to ensure the reliability and availability of your Kafka cluster.
 
 You can read more about this topic [here](https://github.com/confluentinc/librdkafka/wiki/FAQ#is-kafka-up).
 
@@ -406,7 +406,7 @@ Karafka and Karafka Pro do not follow a fixed official release schedule. Instead
 
 - Bug fixes that don't involve API changes are released immediately.
 
-We prioritize bugs and critical performance improvements to ensure optimal user experience and software performance. It's worth noting that most bugs are identified, reproduced, and fixed within seven days from the initial report acknowledgment.
+We prioritize bugs and critical performance improvements to ensure optimal user experience and software performance. Most bugs are identified, reproduced, and fixed within seven days from the initial report acknowledgment.
 
 ## How can I control or limit the number of PostgreSQL database connections when using Karafka?
 
@@ -520,7 +520,7 @@ This approach follows established software architecture principles and provides 
 **Current Status:**
 
 - **Active Support**: The `avro` gem is currently well-maintained and actively supported
-- **Full Integration**: Karafka works seamlessly with Avro serialization for both producers and consumers
+- **Full Integration**: Karafka works with Avro serialization for both producers and consumers
 - **Production Ready**: Many Karafka users successfully use Avro in production environments
 
 **Contingency Planning:**

--- a/Basics/FAQ/Consuming.md
+++ b/Basics/FAQ/Consuming.md
@@ -149,7 +149,7 @@ When a message is produced to a Kafka topic, it is stored in Kafka until it expi
 
 Karafka's [Expiring Messages](Pro-Consumer-Groups-Expiring-Messages) functionality removes messages from Karafka's internal processing queue after a specified amount of time has passed since the message was produced. This functionality is useful when processing messages with a limited lifetime, such as messages with time-sensitive data or messages that should not be processed after a certain amount of time has passed.
 
-However, it's important to note that Karafka's Expiring Messages functionality does not remove messages from Kafka itself, and it only removes messages from Karafka's internal processing queue. Therefore, the retention policy of the Kafka topic will still apply, and the message will remain in Kafka until it expires based on the topic's retention policy.
+However, Karafka's Expiring Messages functionality does not remove messages from Kafka itself, and it only removes messages from Karafka's internal processing queue. Therefore, the retention policy of the Kafka topic will still apply, and the message will remain in Kafka until it expires based on the topic's retention policy.
 
 To set the retention policy of a Kafka topic, you can use Kafka's built-in retention policies or configure custom retention policies using the [declarative topics](Infrastructure-Declarative-Topics) functionality. By configuring the retention policy, you can control how long messages are kept in Kafka before they are deleted, regardless of whether Karafka has processed them or not.
 
@@ -401,11 +401,11 @@ Karafka Pro's Routing Patterns feature allows for flexible routing using regular
 
 ## What does setting the `initial_offset` to `earliest` mean in Karafka? Does it mean the consumer starts consuming from the earliest message that has not been consumed yet?
 
-The `initial_offset` setting in Karafka is relevant only during the initial start of a consumer in a consumer group. It dictates the starting point for message consumption when a consumer group first encounters a topic. Setting `initial_offset` to `earliest` causes the consumer to start processing from the earliest available message in the topic (usually the message with offset 0, but not necessarily). Conversely, setting it to `latest` instructs the consumer to begin processing the next message after the consumer has started. It's crucial to note that `initial_offset` does not influence the consumption behavior during ongoing operations. For topics the consumer group has previously consumed, Karafka will continue processing from the last acknowledged message, ensuring that no message is missed or processed twice.
+The `initial_offset` setting in Karafka is relevant only during the initial start of a consumer in a consumer group. It dictates the starting point for message consumption when a consumer group first encounters a topic. Setting `initial_offset` to `earliest` causes the consumer to start processing from the earliest available message in the topic (usually the message with offset 0, but not necessarily). Conversely, setting it to `latest` instructs the consumer to begin processing the next message after the consumer has started. `initial_offset` does not influence the consumption behavior during ongoing operations. For topics the consumer group has previously consumed, Karafka will continue processing from the last acknowledged message, ensuring that no message is missed or processed twice.
 
 ## How can I set up custom, per-message tracing in Karafka?
 
-Implementing detailed, per-message tracing in Karafka involves modifying the monitoring and tracing setup to handle individual messages. This setup enhances visibility into each message's processing and integrates seamlessly with many tracing products like DataDog.
+Implementing detailed, per-message tracing in Karafka involves modifying the monitoring and tracing setup to handle individual messages. This setup enhances visibility into each message's processing and integrates with many tracing products like DataDog.
 
 Here's how you can set up this  detailed tracing step-by-step:
 

--- a/Basics/FAQ/Errors-and-Troubleshooting.md
+++ b/Basics/FAQ/Errors-and-Troubleshooting.md
@@ -144,7 +144,7 @@ There are several reasons why a Kafka broker might reject some messages:
 - Authorization failure: If the client does not have the required permissions to write to the topic, the broker may reject the message.
 - Broker capacity limitations: If the broker has limited resources and cannot handle the incoming message traffic, it may reject some messages.
 
-To resolve this error, it is essential to identify the root cause of the issue. Checking the message format and schema, ensuring proper authorization and permission, checking broker capacity, and addressing network issues can help resolve the issue. Additionally, monitoring Karafka logs to identify and resolve problems as quickly as possible is crucial.
+To resolve this error, identify the root cause of the issue. Checking the message format and schema, ensuring proper authorization and permission, checking broker capacity, and addressing network issues can help resolve the issue. Additionally, monitoring Karafka logs to identify and resolve problems as quickly as possible is crucial.
 
 ## What does `Broker: Unknown topic or partition` error mean?
 
@@ -200,7 +200,7 @@ For consumers, this disconnection is handled automatically - librdkafka reconnec
 
 Suppose your data production patterns are not stable, and there are times when your client application is not producing any data to Kafka for over 10 minutes. In that case, you may want to consider setting the `log.connection.close` value to `false` in your configuration. This configuration parameter controls whether the client logs a message when a connection is closed by the broker. By default, the client will log a message indicating that the connection was closed, which can generate false alarms if the connection was closed due to inactivity by the connection reaper.
 
-Setting `log.connection.close` to false will suppress these log messages and prevent the error from being raised. It's important to note that even if you set `log.connection.close` to `false,` critical non-recoverable errors that occur in Karafka and WaterDrop will still be reported via the instrumentation pipeline.
+Setting `log.connection.close` to false will suppress these log messages and prevent the error from being raised. Even if you set `log.connection.close` to `false,` critical non-recoverable errors that occur in Karafka and WaterDrop will still be reported via the instrumentation pipeline.
 
 ```ruby
 class KarafkaApp < Karafka::App
@@ -215,7 +215,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-Please note that you can control the `connections.max.idle.ms` on both Kafka and Karafka consumer / WaterDrop producer basis.
+You can control the `connections.max.idle.ms` on both Kafka and Karafka consumer / WaterDrop producer basis.
 
 You can read more about this issue [here](https://github.com/confluentinc/librdkafka/wiki/FAQ#why-am-i-seeing-receive-failed-disconnected).
 
@@ -318,7 +318,7 @@ Please review and update your Kafka ACLs or broker configurations to ensure thes
 
 ## Why am I getting an `ArgumentError: undefined class/module YAML::Syck` when trying to install `karafka-license`?
 
-The error `ArgumentError: undefined class/module YAML::Syck` you're seeing when trying to install `karafka-license` is not directly related to the `karafka-license` gem. It's important to note that `karafka-license` does not serialize data using `YAML::Syck`.
+The error `ArgumentError: undefined class/module YAML::Syck` you're seeing when trying to install `karafka-license` is not directly related to the `karafka-license` gem. `karafka-license` does not serialize data using `YAML::Syck`.
 
 Instead, this error is a manifestation of a known bug within the Bundler and the Ruby gems ecosystem. During the installation of `karafka-license`, other gems may also be installed or rebuilt, triggering this issue.
 
@@ -471,7 +471,7 @@ There are a few potential workarounds:
     end
     ```
 
-It is worth pointing out that this is not a Karafka-specific issue. While the issue manifests when using Karafka with Puma, it's more related to how macOS handles forking with Objective-C libraries and specific initializations post-fork.
+This is not a Karafka-specific issue. While the issue manifests when using Karafka with Puma, it's more related to how macOS handles forking with Objective-C libraries and specific initializations post-fork.
 
 ## What causes a "Broker: Policy violation (policy_violation)" error when using Karafka, and how can I resolve it?
 

--- a/Basics/FAQ/Performance-and-Scaling.md
+++ b/Basics/FAQ/Performance-and-Scaling.md
@@ -30,7 +30,7 @@
 
 ## Why is Karafka not doing work in parallel when I started two processes?
 
-Please make sure your topic contains more than one partition. Only then Karafka can distribute the work to more processes. Keep in mind, that all the topics create automatically with the first message sent will always contain only one partition. Use the Admin API to create topics with more partitions.
+Please make sure your topic contains more than one partition. Only then Karafka can distribute the work to more processes. All the topics create automatically with the first message sent will always contain only one partition. Use the Admin API to create topics with more partitions.
 
 ## What is the optimal number of threads to use?
 
@@ -49,7 +49,7 @@ Karafka can parallelize work in a couple of scenarios, but unless you are a [Kar
 
 You can read more about Karafka and Karafka Pro concurrency model [here](Consumer-Groups-Concurrency-and-Multithreading).
 
-It's also essential to monitor the performance of the application and the system as a whole while experimenting with different thread counts. This can help you identify bottlenecks and determine the optimal number of threads for the specific use case.
+Also monitor the performance of the application and the system as a whole while experimenting with different thread counts. This can help you identify bottlenecks and determine the optimal number of threads for the specific use case.
 
 Remember that the optimal number of threads may change as the workload and system resources change over time.
 
@@ -91,7 +91,7 @@ Now, if we look at Karafka, it follows a similar mechanism. In Karafka, by defau
 
 This lag will grow with incoming messages, which is why it's not uncommon to see a lag of the size of one or two batches, especially in topics with high data traffic.
 
-To mitigate this situation, you can configure Karafka to prioritize latency over throughput. That means making Karafka commit offsets more frequently, even after each message, to decrease the lag and to fetch data more frequently in smaller batches. But keep in mind that committing offsets more frequently comes with the cost of reduced throughput, as each offset commit is a network call and can slow down the rate at which messages are consumed.
+To mitigate this situation, you can configure Karafka to prioritize latency over throughput. That means making Karafka commit offsets more frequently, even after each message, to decrease the lag and to fetch data more frequently in smaller batches. But committing offsets more frequently comes with the cost of reduced throughput, as each offset commit is a network call and can slow down the rate at which messages are consumed.
 
 You can adjust this balance between latency and throughput according to your specific use case and the performance characteristics of your Kafka cluster. You could increase the frequency of committing offsets during peak load times and decrease it during off-peak times if it suits your workload pattern.
 
@@ -115,7 +115,7 @@ If your problems originate from batch and message sizes, we recommend looking in
 
 - **Modify the `max_messages` Value**: By adjusting the `max_messages` setting to a lower value, you can control the number of messages deserialized in a batch. Smaller batches mean less memory consumption at a given time, although it might mean more frequent fetch operations. Ensure that you balance memory usage with processing efficiency while adjusting this value.
 
-While tuning these settings can help optimize memory usage, it's essential to remember that it may also influence performance, latency, and other operational aspects of your Karafka applications. Balancing the memory and performance trade-offs based on specific application needs is crucial. Always monitor the impacts of changes and adjust accordingly.
+While tuning these settings can help optimize memory usage, it may also influence performance, latency, and other operational aspects of your Karafka applications. Balancing the memory and performance trade-offs based on specific application needs is crucial. Always monitor the impacts of changes and adjust accordingly.
 
 ## Are Virtual Partitions effective in case of not having IO or not having a lot of data?
 

--- a/Basics/FAQ/Producing.md
+++ b/Basics/FAQ/Producing.md
@@ -108,7 +108,7 @@ end
 
 With this configuration, Karafka will not create any consumer groups and will only initialize the `Karafka.producer`.
 
-Keep in mind that with this configuration, you will not be able to start `karafka server` but you will be able to access `Karafka.producer` from other processes like Puma or Sidekiq.
+With this configuration, you will not be able to start `karafka server` but you will be able to access `Karafka.producer` from other processes like Puma or Sidekiq.
 
 ## Why am I getting the `can't alloc thread (ThreadError)` error from the producer?
 
@@ -172,7 +172,7 @@ rescue Rdkafka::RdkafkaError do |e|
 end
 ```
 
-If you aim for maximum performance in your Karafka application, you can disable metrics collection by setting the `statistics.interval.ms` configuration to `0`. Doing so effectively disables the collection and emission of statistics data. This can be beneficial in scenarios where every bit of performance matters and you want to minimize any overhead caused by metric aggregation. However, it's important to note that disabling metrics collection will also prevent the Karafka Web UI from collecting important information, such as producer errors, including those in background threads. Therefore, consider the trade-off between performance optimization and the loss of detailed error tracking when deciding whether to disable metrics collection.
+If you aim for maximum performance in your Karafka application, you can disable metrics collection by setting the `statistics.interval.ms` configuration to `0`. Doing so effectively disables the collection and emission of statistics data. This can be beneficial in scenarios where every bit of performance matters and you want to minimize any overhead caused by metric aggregation. However, disabling metrics collection will also prevent the Karafka Web UI from collecting important information, such as producer errors, including those in background threads. Therefore, consider the trade-off between performance optimization and the loss of detailed error tracking when deciding whether to disable metrics collection.
 
 ## Can `at_exit` be used to close the WaterDrop producer?
 
@@ -188,7 +188,7 @@ WaterDrop's `max_payload_size` and librdkafka's `message.max.bytes` are both set
 
 WaterDrop's `max_payload_size` is a configuration parameter employed for internal validation within the WaterDrop producer library. This setting is used to limit the size of the messages before they're dispatched. If a message exceeds the `max_payload_size`, an error is raised, preventing the dispatch attempt. This setting helps ensure that you don't send messages larger than intended.
 
-On the other hand, librdkafka's `message.max.bytes` configuration is concerned with the Kafka protocol's message size. It represents the maximum permissible size of a message in line with the Kafka protocol, and the librdkafka library validates it. Essentially, it determines the maximum size of a ProduceRequest in Kafka.
+On the other hand, librdkafka's `message.max.bytes` configuration is concerned with the Kafka protocol's message size. It represents the maximum permissible size of a message in line with the Kafka protocol, and the librdkafka library validates it. It determines the maximum size of a ProduceRequest in Kafka.
 
 It's advisable to align these two settings to maintain consistency between the maximum payload size defined by WaterDrop and the Kafka protocol. To ensure that larger-than-expected messages are not accepted, it's beneficial to set the `max_payload_size` in WaterDrop. And for `message.max.bytes` in librdkafka, you might want to set it to the same value or even higher, bearing in mind its role in the Kafka protocol.
 
@@ -196,7 +196,7 @@ There are a few nuances to be aware of, which are often seen as "edge cases." On
 
 Another noteworthy point is that if you set `message.max.bytes` to a low yet acceptable value, it could affect the batching process of librdkafka. Specifically, librdkafka might not be able to build larger message batches, leading to data being sent in much smaller batches, sometimes even as small as a single message. This could consequently limit the throughput.
 
-A detailed discussion on this topic can be found on this [GitHub thread](https://github.com/confluentinc/librdkafka/issues/3246). Please note that this discussion remains open, indicating this topic's complexity and continuous exploration.
+A detailed discussion on this topic can be found on this [GitHub thread](https://github.com/confluentinc/librdkafka/issues/3246). This discussion remains open, indicating this topic's complexity and continuous exploration.
 
 Lastly, while the term `message.max.bytes` may not be intuitively understandable, its role in managing message size within the Kafka ecosystem is crucial.
 
@@ -232,7 +232,7 @@ puts error.cause
 #<Rdkafka::AbstractHandle::WaitTimeoutError: Waiting for delivery timed out after 5 seconds>
 ```
 
-Please note that in the case of the `WaitTimeoutError`, the message may actually be delivered but in a more extended time because of the network or other issues. Always instrument your producers to ensure that you are notified about errors occurring in Karafka and WaterDrop internal background threads as well.
+In the case of the `WaitTimeoutError`, the message may actually be delivered but in a more extended time because of the network or other issues. Always instrument your producers to ensure that you are notified about errors occurring in Karafka and WaterDrop internal background threads as well.
 
 The exact cause can often be determined by examining the error message and stack trace accompanying the `WaterDrop::Errors::ProduceError`. Also, check the Kafka logs for more information. If the error message or logs aren't clear, you should debug your code or configuration to identify the problem.
 

--- a/Basics/Why-Kafka-and-Karafka.md
+++ b/Basics/Why-Kafka-and-Karafka.md
@@ -18,7 +18,7 @@ Kafka breaks the request-response constraint without requiring you to rewrite yo
 
 The practical consequences are significant:
 
-- **New consumers cost nothing to add.** A new service that needs to react to `order.placed` events simply subscribes to the topic. The publishing side changes nothing. There is no tight coupling between producers and consumers.
+- **New consumers cost nothing to add.** A new service that needs to react to `order.placed` events subscribes to the topic. The publishing side changes nothing. There is no tight coupling between producers and consumers.
 - **Replay is possible.** If you ship a bug in a consumer, fix it, reset the consumer offset, and reprocess from the point of failure. With Sidekiq, those jobs are gone.
 - **Multiple independent consumers read the same data.** Your analytics pipeline, your notification service, and your data warehouse can all read the same `user.signup` topic simultaneously without any of them affecting the others.
 - **Cross-service communication becomes a data contract.** Publishing a well-defined event is a stable interface that other teams can depend on without coordinating deployments.

--- a/Infrastructure/Application-Development-vs-Production.md
+++ b/Infrastructure/Application-Development-vs-Production.md
@@ -197,7 +197,7 @@ To ensure a smooth transition when adjusting the classic protocol assignment str
 
 In Kafka, every message (or record) produced to a topic carries metadata, including a timestamp. This timestamp is set by the producer or the broker when the message gets appended to the log. Consumers then use the timestamp to understand the chronological order of messages.
 
-Under regular operations, this system works seamlessly. However, problems arise when there's a time drift between the Kafka cluster nodes and the consumer. Essentially, if the Kafka broker believes it's 2:00 PM, while the consumer thinks it's 1:50 PM, the messages produced in that 10-minute interval by the broker will appear as if they're coming from the "future" when consumed.
+Under regular operations, this system works seamlessly. However, problems arise when there's a time drift between the Kafka cluster nodes and the consumer. If the Kafka broker believes it's 2:00 PM, while the consumer thinks it's 1:50 PM, the messages produced in that 10-minute interval by the broker will appear as if they're coming from the "future" when consumed.
 
 The time synchronization issue usually boils down to the Network Time Protocol (NTP). NTP is a protocol used to synchronize the clocks of computers to some time reference, which can be an atomic clock, GPS, or another reliable source.
 
@@ -231,11 +231,11 @@ In conclusion, while Kafka is a powerful tool, it's essential to remember the im
 
 ### Impact on Karafka
 
-Karafka and Karafka Web UI internal operations starting from `2.2.4` are resilient to this issue, as Karafka normalizes the time for internal computation. While this will not crash your operations, please note that time-sensitive metrics may not be accurate.
+Karafka and Karafka Web UI internal operations starting from `2.2.4` are resilient to this issue, as Karafka normalizes the time for internal computation. While this will not crash your operations, time-sensitive metrics may not be accurate.
 
 ## Configure your brokers' `offsets.retention.minutes` policy
 
-`offsets.retention.minutes` in Apache Kafka is a configuration setting that determines how long the Kafka broker will retain the offsets of consumer groups. The offset is a crucial piece of information that records the position of a consumer in a topic, essentially marking which messages have been processed.
+`offsets.retention.minutes` in Apache Kafka is a configuration setting that determines how long the Kafka broker will retain the offsets of consumer groups. The offset is a crucial piece of information that records the position of a consumer in a topic, marking which messages have been processed.
 
 When a consumer is not running longer than the `offsets.retention.minutes` value, the following impacts can occur:
 
@@ -247,7 +247,7 @@ When a consumer is not running longer than the `offsets.retention.minutes` value
 
 It's essential to set the `offsets.retention.minutes` value considering your consumer applications' most extended expected downtime to avoid these issues. Setting a longer retention period for offsets can be crucial for systems where consumers might be down for extended periods.
 
-It's important to note that while the `offsets.retention.minutes` setting in Kafka might not seem particularly relevant in a development environment, it becomes crucial in a production setting.
+While the `offsets.retention.minutes` setting in Kafka might not seem particularly relevant in a development environment, it becomes crucial in a production setting.
 
 In development, consumer downtimes are generally short, and losing offsets might not have significant consequences as the data is often test data, and reprocessing might not be a concern. However, in a production environment, consumer downtime can be more impactful if a consumer is down for a time exceeding the `offsets.retention.minutes` value. The loss of offset data can lead to significant issues like message reprocessing or missing out on unprocessed messages. This can affect data integrity and processing efficiency.
 
@@ -265,7 +265,7 @@ In Karafka it has specific implications:
 
 - **Topic Auto-Creation Considerations**: While Kafka and, by extension, Karafka support automatic topic creation, it's generally not recommended for consumer applications. Automatic topic creation can lead to issues where consumers attempt to consume from auto-created topics without producers, resulting in empty message sets.
 
-In summary, when working with Kafka through Karafka, it's crucial to understand the asynchronous nature of Kafka's topic management. Developers should plan for propagation delays, be cautious with topic resets, and manage auto-creation settings judiciously to ensure a robust and reliable streaming application.
+In summary, when working with Kafka through Karafka, it's crucial to understand the asynchronous nature of Kafka's topic management. Developers should plan for propagation delays, be cautious with topic resets, and manage auto-creation settings judiciously to ensure a reliable streaming application.
 
 ## `zstd` Support Issues on macOS
 

--- a/Infrastructure/Deployment.md
+++ b/Infrastructure/Deployment.md
@@ -94,7 +94,7 @@ CMD bundle exec karafka server
 
 ## AWS + MSK (Fully Managed Apache Kafka)
 
-First of all, it is worth pointing out that Karafka, similar to librdkafka does **not** support SASL mechanism for AWS MSK IAM that allows Kafka clients to handle authentication and authorization with MSK clusters through [AWS IAM](https://aws.amazon.com/iam/). This mechanism is a proprietary idea that is not part of Kafka.
+First of all, Karafka, similar to librdkafka does **not** support SASL mechanism for AWS MSK IAM that allows Kafka clients to handle authentication and authorization with MSK clusters through [AWS IAM](https://aws.amazon.com/iam/). This mechanism is a proprietary idea that is not part of Kafka.
 
 Karafka **does**, however, support:
 
@@ -249,7 +249,7 @@ This means Kafka is unreachable. Check your brokers' addresses and ensure you us
 
 ### Connection failures and timeouts
 
-Please make sure that your instances can reach Kafka. Keep in mind that security group updates can have a certain lag in propagation.
+Please make sure that your instances can reach Kafka. Security group updates can have a certain lag in propagation.
 
 If a previously healthy producer starts stalling on delivery (each stalled message blocking for as long as your configured `socket.timeout.ms`, with `Timed out N in-flight ... requests` warnings) after an EC2 instance type upgrade to a newer generation such as the Graviton `*9g` families, the likely cause is the Nitro v6 ENI idle-connection timeout (lowered from 5 days to 350 seconds), which silently drops idle producer sockets. Enable `socket.keepalive.enable: true`, tune the host TCP keepalive timers below 350 seconds (on Kubernetes, through pod `securityContext.sysctls`), and set WaterDrop's `idle_disconnect_timeout` to recycle idle producers proactively. See the [AWS MSK Guide](Infrastructure-AWS-MSK-Guide#ec2-nitro-v6-idle-connection-reaping) for the full explanation, the keepalive sysctl values, and the timeout and retry settings recommended for MSK.
 
@@ -265,7 +265,7 @@ Please make sure your custom setting `default.replication.factor` value matches 
 
 This error occurs in case you enabled Kafka ACL but did not grant proper ACL permissions to your users. It often happens when you make your [AWS MSK public](https://docs.aws.amazon.com/msk/latest/developerguide/public-access.html).
 
-Please note that `allow.everyone.if.no.acl.found` `false` superseeds `auto.create.topics.enable`. This means that despite `auto.create.topics.enable` being set to `true`, you will not be able to auto-create topics as the ACL will block this.
+`allow.everyone.if.no.acl.found` `false` superseeds `auto.create.topics.enable`. This means that despite `auto.create.topics.enable` being set to `true`, you will not be able to auto-create topics as the ACL will block this.
 
 We recommend creating all the needed topics before making the cluster public and assigning proper permissions via Kafka ACL.
 

--- a/Infrastructure/Resources-Management.md
+++ b/Infrastructure/Resources-Management.md
@@ -12,7 +12,7 @@ The C `librdkafka` client library, which Karafka uses under the hood, uses `2` t
 
 The Kafka cluster size can also affect the number of threads since Karafka maintains connections with multiple brokers in a cluster. Therefore, a larger cluster size may result in more threads. A single consumer group Karafka server process in a Ruby on Rails application on a small cluster will have about `25` to `30` threads.
 
-This may sound like a lot, but for comparison, Puma, a popular Ruby web server in a similar app, will have around `21` to `25` threads. It's important to note that having a higher thread count in Karafka is perfectly normal. Karafka is designed to handle the complexity of multiple brokers and consumer groups in a Kafka cluster, which inherently requires more threads.
+This may sound like a lot, but for comparison, Puma, a popular Ruby web server in a similar app, will have around `21` to `25` threads. Having a higher thread count in Karafka is perfectly normal. Karafka is designed to handle the complexity of multiple brokers and consumer groups in a Kafka cluster, which inherently requires more threads.
 
 Karafka Pro Web-UI gives you enhanced visibility into your Karafka server processes. This includes the ability to inspect the thread count on a per-process basis. This detailed view can provide invaluable insights, helping you understand how your Karafka server is performing and where any potential bottlenecks might occur.
 
@@ -157,7 +157,7 @@ Under normal circumstances, Karafka will use the `concurrency` number of databas
 
 However, the number of potential concurrent database connections might increase when using advanced Karafka APIs, such as the Filtering API, or making alterations to the scheduler and invoking DB requests from it. This is because these APIs operate from the listeners threads. In such advanced scenarios, the maximum number of concurrent DB connections would be the sum of the number of workers (`concurrency`) and the total number of subscription groups.
 
-It's important to note that a situation where all these threads would execute database operations simultaneously is highly unlikely. Therefore, in most use cases, the simplified assumption that only the `concurrency` parameter determines potential DB connections should suffice.
+A situation where all these threads would execute database operations simultaneously is highly unlikely. Therefore, in most use cases, the simplified assumption that only the `concurrency` parameter determines potential DB connections should suffice.
 
 ## Memory Usage
 
@@ -169,7 +169,7 @@ Karafka demonstrates robustness and efficiency in managing memory resources, par
 
 - **Batch Processing and Memory Release**: By default, Karafka retains the memory occupied by messages and their payload until an entire batch is processed. Karafka makes no assumptions about the nature of the processing. While this ensures flexibility in handling complex workflows, it can also increase memory usage during high-throughput operations. For those looking to optimize memory management and release message memory more proactively, Karafka Pro offers a [Cleaner API](Pro-Cleaner-API).
 
-- **Ruby Version Considerations**: It's important to note that external factors such as Ruby versions can affect memory usage. For instance, Ruby `3.3.0` has been observed to have memory leak issues due to bugs introduced in that version.
+- **Ruby Version Considerations**: External factors such as Ruby versions can affect memory usage. For instance, Ruby `3.3.0` has been observed to have memory leak issues due to bugs introduced in that version.
 
 - **Impact of High Throughput**: Karafka's design to handle tens of thousands of messages per second means that any memory leaks in other gems or the application code can be more problematic than in traditional web applications. The high message throughput can quickly escalate minor leaks into significant issues, affecting system stability and performance.
 

--- a/WaterDrop/Configuration.md
+++ b/WaterDrop/Configuration.md
@@ -246,7 +246,7 @@ producer.setup do |config|
 end
 ```
 
-Keep in mind, that to use `zstd`, you need to install `libzstd-dev`:
+To use `zstd`, you need to install `libzstd-dev`:
 
 ```shell
 apt-get install -y libzstd-dev
@@ -270,7 +270,7 @@ There are three primary parameters to consider:
 
     - Before a message reaches librdkafka, WaterDrop checks the `max_payload_size` to ensure the message payload is within permissible limits.
 
-    - It's worth noting that this validation only concerns the payload and not additional elements like metadata, headers, and key.
+    - This validation only concerns the payload and not additional elements like metadata, headers, and key.
 
 1. **librdkafka Validation**:
 

--- a/WaterDrop/Usage.md
+++ b/WaterDrop/Usage.md
@@ -49,7 +49,7 @@ Here are all the things you can provide in the message hash:
 | `headers`       | false    | Hash          | Headers for the message                                  |
 | `label`         | false    | Object        | Anything you want to use as a label                      |
 
-Keep in mind, that message you want to send should be either binary or stringified (to_s, to_json, etc).
+The message you want to send should be either binary or stringified (to_s, to_json, etc).
 
 ## Headers
 
@@ -354,7 +354,7 @@ Properly shutting down WaterDrop producers is crucial to ensure graceful handlin
 
 It is essential to close the WaterDrop producer before exiting the Ruby process. Closing the producer allows it to release resources, complete ongoing operations, and ensure that all messages are either successfully delivered to the Kafka cluster or purged due to exceeding the `message.timeout.ms` value.
 
-The `#close` method is used to shut down the producer. It is important to note that `#close` is a blocking operation, meaning it will block the execution of your program until all the necessary resources are cleaned up. Therefore, it is not recommended to start the `#close` operation in a separate thread and not wait for it to finish, as this may lead to unexpected behavior.
+The `#close` method is used to shut down the producer. `#close` is a blocking operation, meaning it will block the execution of your program until all the necessary resources are cleaned up. Therefore, it is not recommended to start the `#close` operation in a separate thread and not wait for it to finish, as this may lead to unexpected behavior.
 
 Here is an example of how to use #close to shut down a producer:
 

--- a/Web-UI/Getting-Started.md
+++ b/Web-UI/Getting-Started.md
@@ -270,7 +270,7 @@ This makes deployments on Linux systems (especially in containers) simpler and m
 
 ## Zero-Downtime Deployment
 
-For those who consider `karafka server` indispensable to their production infrastructure, there's a way to integrate the Karafka Web UI without inducing downtime. Let's dive into the steps to introduce it seamlessly:
+For those who consider `karafka server` indispensable to their production infrastructure, there's a way to integrate the Karafka Web UI without inducing downtime. Let's dive into the steps to introduce it:
 
 1. **Integration**: Begin by installing the Karafka Web UI. Ensure it's appropriately configured in your `karafka.rb` and works for you locally.
 
@@ -353,7 +353,7 @@ Rails.application.routes.draw do
 end
 ```
 
-By implementing these practices, you ensure that the authentication process for the Karafka Web UI does not expose any sensitive information through timing analysis, thereby maintaining robust security standards.
+By implementing these practices, you ensure that the authentication process for the Karafka Web UI does not expose any sensitive information through timing analysis, thereby maintaining security standards.
 
 ## Kafka ACL Requirements
 
@@ -496,7 +496,7 @@ When upgrading Karafka Web UI, particularly to versions with breaking changes, a
 
 Starting from version `0.7.4`, the Karafka Web UI introduces enhanced schema detection capabilities. If an older consumer responsible for materializing the Web UI results encounters an unsupported newer schema, it will detect this incompatibility. Upon detection, the consumer will emit an error and start a backoff procedure, ensuring the system's stability and predictability.
 
-Furthermore, it's worth noting that if Karafka Web UI detects older schema reports during its operation, it will ignore such reports. However, this behavior is exclusive to short-lived per-process reports and only occurs in the context of upgrades introducing breaking changes to the schema. Importantly, error reports will **always** be processed and are **never** ignored, regardless of their schema version.
+Furthermore, if Karafka Web UI detects older schema reports during its operation, it will ignore such reports. However, this behavior is exclusive to short-lived per-process reports and only occurs in the context of upgrades introducing breaking changes to the schema. Importantly, error reports will **always** be processed and are **never** ignored, regardless of their schema version.
 
 Ignoring these older schema reports might introduce slight discrepancies in the metrics. However, this approach is deliberate and is designed to safeguard the system. By ignoring such reports, we ensure that any potential incompatibilities in the reporting do not adversely affect the system's functionality. This serves as a safety mechanism, especially when it was impossible or overlooked to shut down all consumers during an upgrade.
 


### PR DESCRIPTION
…r, marketing fluff)

Apply the readability rules already documented in Development/Technical-Writing.md (lines 72-74) to the highest-traffic pages: cut throat-clearing openers ('It is important to note that', 'Please note that', 'Keep in mind that', 'It is worth noting that'), delete minimizing filler ('essentially', 'simply'), and remove empty marketing words ('robust', 'seamless', 'comprehensive', 'powerful') where they carry no information.

43 changes across 13 files (FAQ set, Basics, Infrastructure, WaterDrop, Web-UI). Judgment-based, not mechanical: load-bearing words were kept (e.g. 'comprehensive list' meaning exhaustive, 'powerful' where the sentence substantiates a specific capability, 'robustness'/'efficiency' nouns), and code, links, headings, and admonition titles were left untouched.

Verified: npm run lint clean, ./bin/mklint strict build passes, every link/anchor target and inline-code span byte-identical before/after.