### PR TITLE
docs: tighten prose on Pro feature pages (readability, part 2)

### DIFF
--- a/Pro/Consumer-Groups/Delayed-Topics.md
+++ b/Pro/Consumer-Groups/Delayed-Topics.md
@@ -36,7 +36,7 @@ end
 
 !!! note "Delay Time Is Specified in Milliseconds"
 
-    Please keep in mind, that the delay time needs to be provided in milliseconds
+    The delay time needs to be provided in milliseconds
 
 ## Delayed Topics vs. inline `#sleep` invocation
 
@@ -80,7 +80,7 @@ Below is an example distribution of the extra lag beyond the tested and expected
 
 ## Revocation and Shutdown
 
-When using the Delayed Topics feature in Karafka, it is essential to note that both the `#shutdown` and `#revocation` methods may be executed without the prior `#consume` running. This is because Delayed Topics may delay the processing of the first set of messages, which means that the messages batch may be empty, and the first and last offsets taken from metadata will be equal to `-1001`.
+When using the Delayed Topics feature in Karafka, both the `#shutdown` and `#revocation` methods may be executed without the prior `#consume` running. This is because Delayed Topics may delay the processing of the first set of messages, which means that the messages batch may be empty, and the first and last offsets taken from metadata will be equal to `-1001`.
 
 In such scenarios, using the `#used?` method when relying on them in `#revocation` and `#shutdown` is always recommended. This can be done using a conditional statement that checks if there was even a single batch consumed or scheduled for consumption.
 
@@ -119,7 +119,7 @@ class OrdersConsumer < ApplicationConsumer
 end
 ```
 
-It is important to note that Delayed Topics can be a powerful tool for managing message processing, as it allows for messages to be processed in a controlled manner. However, it is essential to understand the potential side effects and implement appropriate error-handling mechanisms to ensure the system remains stable and reliable.
+Delayed Topics can be a powerful tool for managing message processing, as it allows for messages to be processed in a controlled manner. However, understand the potential side effects and implement appropriate error-handling mechanisms to ensure the system remains stable and reliable.
 
 ## Example Use Cases
 

--- a/Pro/Consumer-Groups/Filtering-API.md
+++ b/Pro/Consumer-Groups/Filtering-API.md
@@ -24,7 +24,7 @@ If you plan to implement action-altering filters, you need to define two additio
 
     Always validate your filters to confirm that `#timeout` behaves as expected to avoid unexpected delays or conflicts.
 
-It is essential to remember that post-processing actions may also be applied when no data is left after filtering.
+Remember that post-processing actions may also be applied when no data is left after filtering.
 
 Below is an example implementation of a filter that continuously removes messages with odd offsets. This filter sets the `@applied` in case even one message has been removed.
 
@@ -50,7 +50,7 @@ If you are looking for more extensive examples, you can check out the implementa
 
 ### Filters Lifecycle
 
-Filter instance is created when Karafka encounters a given topic partition for the first time and is long-lived. While their primary responsibility is to filter the incoming data, they can also alter the flow behavior. Hence it is essential to remember that part of their operations happens **after** all the data is being processed at the moment of post-execution strategy application. This means that there may be a significant delay between the filtering and the invocation of `#action` that is equal to the collective processing time of all the data of a given topic partition.
+Filter instance is created when Karafka encounters a given topic partition for the first time and is long-lived. While their primary responsibility is to filter the incoming data, they can also alter the flow behavior. Hence, remember that part of their operations happens **after** all the data is being processed at the moment of post-execution strategy application. This means that there may be a significant delay between the filtering and the invocation of `#action` that is equal to the collective processing time of all the data of a given topic partition.
 
 <p align="center">
   <img src="https://karafka.io/assets/misc/charts/filtering_api_action_application.svg" />

--- a/Pro/Consumer-Groups/Multiplexing.md
+++ b/Pro/Consumer-Groups/Multiplexing.md
@@ -96,7 +96,7 @@ end
       end
     ```
 
-Once you have configured multiplexing in your routing settings, no additional steps are required for it to function. Your application will start processing messages from multiple partitions simultaneously, using the benefits of multiplexing immediately and seamlessly.
+Once you have configured multiplexing in your routing settings, no additional steps are required for it to function. Your application will start processing messages from multiple partitions simultaneously, using the benefits of multiplexing immediately.
 
 ### Configuration API
 
@@ -238,7 +238,7 @@ end
 
 Aside from fixed connections multiplexing, Karafka provides a mode called "Dynamic". Dynamic multiplexing in Karafka is designed to optimize resource utilization and enhance system efficiency. Karafka's dynamic multiplexing adjusts the number of in-process connections based on partition assignments. This assignment-based scaling ensures a balanced and efficient distribution of resources.
 
-It is essential to know the following facts about this mode of operations:
+Know the following facts about this mode of operations:
 
 - **Assignment-Based Scaling**: The system dynamically adjusts connections based on the distribution of partition assignments. This ensures a more effective and targeted scaling strategy, directly aligning with Kafka's data structure and flow.
 
@@ -256,7 +256,7 @@ Here's a breakdown of how it operates when the dynamic mode is enabled:
 
 - **Stabilization Period**: After establishing the initial connections, Karafka enters a stabilization period. It waits for at least one minute following the last rebalance. This waiting period allows the system to stabilize and ensures that decisions to scale down are not made prematurely, which might otherwise lead to unnecessary fluctuations and inefficiencies.
 
-- **Selective Connection Shutdown**: Once the system has stabilized, Karafka begins monitoring the usage of each connection. If it identifies a connection that is not being used (i.e., no partitions are assigned), it will shut it down to conserve resources. However, it's crucial to note that Karafka is designed always to maintain at least `min` active connections, even if no partitions are currently assigned. This ensures that a line is always open to Kafka, ready to take on assignments if the need arises quickly.
+- **Selective Connection Shutdown**: Once the system has stabilized, Karafka begins monitoring the usage of each connection. If it identifies a connection that is not being used (i.e., no partitions are assigned), it will shut it down to conserve resources. However, Karafka is designed always to maintain at least `min` active connections, even if no partitions are currently assigned. This ensures that a line is always open to Kafka, ready to take on assignments if the need arises quickly.
 
 - **Adaptive Scaling Up**: If any subscription group receives multiple assignments and the system has yet to reach the `max` number of active connections, Karafka will adaptively scale up the connections, one at a time. This gradual increase helps efficiently handle the increased load while avoiding abrupt changes that could lead to instability.
 
@@ -357,7 +357,7 @@ end
 
 - **Cost-Effectiveness**: Reduces operational costs by using resources only when necessary and as dictated by the structure and distribution of Kafka partitions.
 
-- **Scalability**: Supports the dynamic and fluctuating nature of distributed data systems without manual intervention, ensuring that the system can seamlessly adapt to varying partition loads.
+- **Scalability**: Supports the dynamic and fluctuating nature of distributed data systems without manual intervention, ensuring that the system can adapt to varying partition loads.
 
 - **Improved Parallelism**: Enhances the system's ability to process data concurrently across multiple partitions and topics, resulting in faster processing times and higher throughput.
 
@@ -419,7 +419,7 @@ This increased memory usage is particularly notable when messages are large or w
 
 ## Summary
 
-Karafka Multiplexing is a powerful tool designed to enhance the performance of your Kafka-based applications, especially under heavy load. Allowing multiple connections to the same topic from a single process provides a robust solution for handling high-volume data streams, optimizing resources, and ensuring high availability. Whether you're dealing with fluctuating workloads, aiming for high throughput, or seeking to improve fault tolerance, Multiplexing can provide significant benefits.
+Karafka Multiplexing is a tool designed to enhance the performance of your Kafka-based applications, especially under heavy load. Allowing multiple connections to the same topic from a single process provides a solution for handling high-volume data streams, optimizing resources, and ensuring high availability. Whether you're dealing with fluctuating workloads, aiming for high throughput, or seeking to improve fault tolerance, Multiplexing can provide significant benefits.
 
 ## See Also
 

--- a/Pro/Consumer-Groups/Offset-Metadata-Storage.md
+++ b/Pro/Consumer-Groups/Offset-Metadata-Storage.md
@@ -1,6 +1,6 @@
 # Offset Metadata Storage
 
-Offset Metadata Storage is a feature within the Karafka framework allowing the addition of metadata to offsets. At its core, Offset Metadata Storage enables developers to attach custom metadata to message offsets when they are committed to the Kafka broker. This metadata, essentially a form of annotation or additional data, can then be retrieved and used for many purposes, enhancing message processing systems' capability, traceability, and intelligence.
+Offset Metadata Storage is a feature within the Karafka framework allowing the addition of metadata to offsets. At its core, Offset Metadata Storage enables developers to attach custom metadata to message offsets when they are committed to the Kafka broker. This metadata, a form of annotation or additional data, can then be retrieved and used for many purposes, enhancing message processing systems' capability, traceability, and intelligence.
 
 In traditional Kafka consumption, a message's offset indicates its position within a partition. While this is crucial for ensuring messages are processed in order, and no message is missed or duplicated, the standard offset mechanism doesn't provide context or additional information about the processing state or the nature of the message. Offset Metadata Storage fills this gap by allowing developers to store custom, context-rich data alongside these offsets.
 
@@ -181,7 +181,7 @@ Offset Metadata Storage in Karafka enhances consumer instances' capability to ma
 
 In scenarios where you need to retrieve offset metadata outside of the consumer instance, for instance, within Filters, to use the Filtering API, Karafka provides a flexible solution. This is especially useful when your processing logic requires insight into the message offsets' metadata at different stages or components of your application, not just within the consumer itself.
 
-As long as the current process retains the assignment of the given topic partition, you can retrieve the offset metadata from places other than the consumer instance. This means that even in filters or other parts of your Karafka application, you can access the metadata associated with any offset, ensuring a seamless and cohesive processing flow.
+As long as the current process retains the assignment of the given topic partition, you can retrieve the offset metadata from places other than the consumer instance. This means that even in filters or other parts of your Karafka application, you can access the metadata associated with any offset, ensuring a cohesive processing flow.
 
 To do so, you need to use the `Karafka::Pro::Processing::OffsetMetadata::Fetcher` object as follows:
 

--- a/Pro/Consumer-Groups/Periodic-Jobs.md
+++ b/Pro/Consumer-Groups/Periodic-Jobs.md
@@ -232,7 +232,7 @@ To maintain accurate and independent ticking, irrespective of polling intervals 
 
 - **Connection Multiplexing**: Implement multiple connections to Kafka within the same application. This ensures that lengthy processing in one part of your application doesn't delay the execution of periodic jobs in another.
 
-- **Long-Running and Non-Blocking Jobs (LRJ/NBJ) Usage**: For scenarios where you are dealing with long-running or non-blocking jobs, it's beneficial to design your tasks so they do not block the main thread. In these cases, the work being processed is non-blocking, meaning that polling and ticking can continue at their configured intervals without being delayed by the processing times of given messages. For topics associated with such jobs, periodic jobs will also become non-blocking and will execute at a consistent and steady frequency. This approach ensures that message processing and periodic tasks can occur seamlessly and independently, maintaining system responsiveness and reliability.
+- **Long-Running and Non-Blocking Jobs (LRJ/NBJ) Usage**: For scenarios where you are dealing with long-running or non-blocking jobs, it's beneficial to design your tasks so they do not block the main thread. In these cases, the work being processed is non-blocking, meaning that polling and ticking can continue at their configured intervals without being delayed by the processing times of given messages. For topics associated with such jobs, periodic jobs will also become non-blocking and will execute at a consistent and steady frequency. This approach ensures that message processing and periodic tasks can occur independently, maintaining system responsiveness and reliability.
 
 ### Persistence of Periodic Jobs During Pauses
 
@@ -242,7 +242,7 @@ Message consumption halts temporarily when a topic partition is paused, typicall
 
 This behavior is particularly beneficial for maintaining consistent operations like monitoring, reporting, or routine maintenance that need to continue irrespective of the consumer's state. It provides a layer of reliability and consistency, ensuring that vital tasks are not missed and that the system remains up-to-date and responsive.
 
-However, it's crucial to be aware of this persistence to manage system resources effectively and avoid unexpected behavior. Knowing that periodic jobs run continuously allows for better planning and utilization of system capabilities, ensuring that the tasks performed during pauses are necessary and optimized for efficiency.
+However, be aware of this persistence to manage system resources effectively and avoid unexpected behavior. Knowing that periodic jobs run continuously allows for better planning and utilization of system capabilities, ensuring that the tasks performed during pauses are necessary and optimized for efficiency.
 
 ```ruby
 class KarafkaApp < Karafka::App
@@ -291,7 +291,7 @@ In Karafka, handling errors occurring in periodic jobs within the `#tick` method
 
 When an error occurs within the `#tick` method, it doesn't trigger the conventional DLQ or retry mechanisms. This is because periodic jobs are inherently different from standard message consumption; they are not associated with a batch of messages that can be retried. Instead, they are period-triggered actions meant to occur regularly. If an error happens during the execution of a `#tick` method, it doesn't prevent the method from being invoked again at the next scheduled interval. The system is designed to continue with the subsequent ticks, ensuring that periodic tasks maintain their rhythm.
 
-Despite not being subject to DLQ or retries, it's crucial to monitor and manage errors effectively. In Karafka, errors within the `#tick` method are published to the `error.occurred` notification channel. This allows for centralized monitoring and handling of errors. Each error notification event carries a `:type` set to `consumer.tick.error`, distinguishing it clearly as an error from the periodic job's tick operation. This explicit categorization aids in pinpointing the source of errors and facilitates more efficient debugging and error-handling strategies.
+Despite not being subject to DLQ or retries, monitor and manage errors effectively. In Karafka, errors within the `#tick` method are published to the `error.occurred` notification channel. This allows for centralized monitoring and handling of errors. Each error notification event carries a `:type` set to `consumer.tick.error`, distinguishing it clearly as an error from the periodic job's tick operation. This explicit categorization aids in pinpointing the source of errors and facilitates more efficient debugging and error-handling strategies.
 
 By understanding and using this behavior, developers can ensure that their periodic jobs in Karafka are robust and operate smoothly, even in the face of intermittent errors. It also underscores the importance of monitoring and responding to the error.occurred notifications to maintain the health and reliability of the system.
 

--- a/Pro/Consumer-Groups/Scheduling-API.md
+++ b/Pro/Consumer-Groups/Scheduling-API.md
@@ -26,7 +26,7 @@ The Listener thread serves two critical functions:
 
 The Listener thread, therefore, acts as the bridge between Kafka and Karafka's internal processing mechanisms, ensuring a steady flow of data into the system.
 
-It is important to note that the Listener thread in Karafka is designed to recognize when not to poll more data from Kafka. This mechanism ensures that it refrains from fetching additional messages if the system is currently processing a workload or if certain conditions necessitating a data ingestion pause are met. Essentially, the Listener thread only polls for more data when the system is ready, thereby maintaining a balanced and efficient processing environment.
+The Listener thread in Karafka is designed to recognize when not to poll more data from Kafka. This mechanism ensures that it refrains from fetching additional messages if the system is currently processing a workload or if certain conditions necessitating a data ingestion pause are met. Essentially, the Listener thread only polls for more data when the system is ready, thereby maintaining a balanced and efficient processing environment.
 
 ### Worker Threads
 
@@ -40,7 +40,7 @@ In environments with high volumes of data or complex processing requirements, mu
 
 ### Conclusion
 
-The Listener and Worker threads in Karafka are central to its architecture, working in tandem to ensure efficient data flow and processing. The Listener thread's role in fetching data and triggering scheduling, combined with the Worker thread's job execution responsibilities, creates a robust and scalable system capable of handling the demands of real-time data processing with Kafka.
+The Listener and Worker threads in Karafka are central to its architecture, working in tandem to ensure efficient data flow and processing. The Listener thread's role in fetching data and triggering scheduling, combined with the Worker thread's job execution responsibilities, creates a scalable system capable of handling the demands of real-time data processing with Kafka.
 
 Below, you can find a simplified illustration of the cooperation of Listener and Worker threads and their connection via the jobs queue.
 
@@ -94,7 +94,7 @@ In contrast, a stateless scheduler does not retain state information from one ta
 
 !!! note "Each Method Has a Non-Blocking `on_` Counterpart"
 
-    Please note that each method described in the following section has a non-blocking counterpart. These are easily identifiable by their `on_` prefix. For instance, for the method named `manage`, its non-blocking equivalent is `on_manage`.
+    Each method described in the following section has a non-blocking counterpart. These are easily identifiable by their `on_` prefix. For instance, for the method named `manage`, its non-blocking equivalent is `on_manage`.
 
 The custom scheduler should inherit from the `Karafka::Pro::Processing::Schedulers::Base` class and, depending on needs, should define following methods:
 

--- a/Pro/Consumer-Groups/Transactions.md
+++ b/Pro/Consumer-Groups/Transactions.md
@@ -16,7 +16,7 @@ Karafka transactions provide Exactly-Once Semantics by ensuring that producing t
 
 !!! tip "Scope of WaterDrop Transactions"
 
-    Please note that **this document concentrates solely on the consumer-related aspects of Karafka's transactions**. For a comprehensive understanding of transactions and to ensure a well-rounded mastery of Karafka's transactional capabilities, delving into the [WaterDrop transactions documentation](WaterDrop-Transactions) is imperative.
+    **This document concentrates solely on the consumer-related aspects of Karafka's transactions**. For a comprehensive understanding of transactions and to ensure a well-rounded mastery of Karafka's transactional capabilities, delving into the [WaterDrop transactions documentation](WaterDrop-Transactions) is imperative.
 
 !!! warning "Avoid Mixing Transactional and Non-Transactional Offset Committing"
 
@@ -128,7 +128,7 @@ def consume
 end
 ```
 
-Karafka recognizes and harmonizes the two flows when integrating transactions with this automatic offset management. This allows for the seamless use of transactions and the explicit marking of messages as consumed within these transactions without interfering with Karafka's implicit offset management behavior.
+Karafka recognizes and harmonizes the two flows when integrating transactions with this automatic offset management. This allows for the use of transactions and the explicit marking of messages as consumed within these transactions without interfering with Karafka's implicit offset management behavior.
 
 ```ruby
 def consume
@@ -180,7 +180,7 @@ end
 
     When providing a custom producer directly to the `#transaction` method while using manual offset management, you must ensure that no Karafka features that automatically manage and store offsets are used in your consumer. Any inadvertent offset management by Karafka could interfere with the integrity of your manual offset strategy.
 
-    In many cases, it may be a better idea to use the `#wrap` API, even when using manual offset management. The `#wrap` API allows you to handle custom producer assignment and lifecycle management seamlessly, while still ensuring that the overall Karafka consumption flow - including synchronization and framework-level operations-executes correctly. This approach reduces the risk of inconsistencies and simplifies producer handling in complex scenarios.
+    In many cases, it may be a better idea to use the `#wrap` API, even when using manual offset management. The `#wrap` API allows you to handle custom producer assignment and lifecycle management, while still ensuring that the overall Karafka consumption flow - including synchronization and framework-level operations-executes correctly. This approach reduces the risk of inconsistencies and simplifies producer handling in complex scenarios.
 
 ### Using a Dedicated Transactional Producer
 
@@ -268,7 +268,7 @@ In essence, with support for dedicated transactional producers, Karafka's `#tran
 
     In these scenarios, the Karafka framework might invoke the transactional producer after the main consumption logic completes. This implicit usage could lead to unintended transactional behavior or conflicts, undermining the integrity of your processing logic.
 
-    The recommended approach is to use the `#wrap` method when customizing the producer. This ensures that the transactional producer is seamlessly managed across the entire lifecycle of the action, including any framework-level operations that occur after your custom logic. By adhering to this practice, you maintain consistency, avoid unexpected issues, and fully use the robustness of Karafka's transactional processing capabilities.
+    The recommended approach is to use the `#wrap` method when customizing the producer. This ensures that the transactional producer is managed across the entire lifecycle of the action, including any framework-level operations that occur after your custom logic. By adhering to this practice, you maintain consistency, avoid unexpected issues, and fully use the robustness of Karafka's transactional processing capabilities.
 
 !!! warning "Ensure `#wrap` Always Calls `yield`"
 
@@ -337,7 +337,7 @@ end
 
 Providing a custom producer to the `#transaction` method temporarily overwrites the default producer for that specific consumer instance. This behavior is relevant in scenarios involving [Long-Running Jobs](Pro-Consumer-Groups-Long-Running-Jobs) that execute alongside the message consumption process, such as handling `#revoked` under Long Running Jobs (LRJ).
 
-It's crucial to understand the implications of this producer reassignment:
+Understand the implications of this producer reassignment:
 
 - **Temporary Producer Reassignment**: During the transaction's execution, the custom producer you provide becomes the active producer for the consumer. Any operations within the transaction's scope will use this custom producer instead of the default one.
 
@@ -432,7 +432,7 @@ Specific scenarios, like partition revocation, can introduce complexities that m
 
 1. **Handling Assignment Loss During Transactions**: If the assignment is lost while a transaction is in progress, the transaction is automatically rolled back, and an error is raised. This rollback is crucial to maintaining the atomicity and integrity of transactions, ensuring that partial or inconsistent states do not persist in the system.
 
-In summary, Karafka's transaction handling after revocation is designed to maintain the integrity and consistency of message processing. By allowing message production to continue post-revocation and ensuring that consumption marking is tightly controlled, Karafka provides a robust framework for managing transactions, even in the face of complex distributed system behaviors like partition revocation.
+In summary, Karafka's transaction handling after revocation is designed to maintain the integrity and consistency of message processing. By allowing message production to continue post-revocation and ensuring that consumption marking is tightly controlled, Karafka provides a framework for managing transactions, even in the face of complex distributed system behaviors like partition revocation.
 
 ### Transactions in the Dead-Letter Queue
 
@@ -444,7 +444,7 @@ This section explains how transactions interact with the DLQ and the implication
 
     !!! note "Disabling Transactions During DLQ Dispatches"
 
-        It's worth noting that this behavior can be adjusted. If the transactional mode in the DLQ configuration is turned off, Karafka won't use transactions to move messages to the DLQ. You can read more about this [here](Pro-Consumer-Groups-Enhanced-Dead-Letter-Queue#disabling-transactions-during-dlq-dispatches).
+        This behavior can be adjusted. If the transactional mode in the DLQ configuration is turned off, Karafka won't use transactions to move messages to the DLQ. You can read more about this [here](Pro-Consumer-Groups-Enhanced-Dead-Letter-Queue#disabling-transactions-during-dlq-dispatches).
 
 1. **Error Handling and Retries**: If an error occurs during the DLQ operation, such as partition revocation or networking issues, Karafka's default behavior is to retry processing the same batch. This retry mechanism ensures that transient failures don't lead to message loss or unacknowledged message consumption. The system attempts to process the batch again, allowing the operation to succeed.
 
@@ -452,7 +452,7 @@ This section explains how transactions interact with the DLQ and the implication
 
 In such cases, it's important to understand that the DLQ might not operate, meaning that messages that fail processing persistently might not be moved to the DLQ. This situation underscores the importance of monitoring and potentially adjusting the system configuration or handling mechanisms to ensure that messages are either processed successfully or reliably moved to the DLQ.
 
-In conclusion, while transactions in Karafka provide a robust mechanism for processing messages consistently and atomically, their interaction with the DLQ introduces specific behaviors and considerations.
+In conclusion, while transactions in Karafka provide a mechanism for processing messages consistently and atomically, their interaction with the DLQ introduces specific behaviors and considerations.
 
 ## Delivery Warranties
 
@@ -474,13 +474,13 @@ Here's how Karafka's delivery warranties manifest in transactions:
 
 ## Instrumentation
 
-Transactions Instrumentation is directly tied to the **producer** handling the transaction. To effectively monitor transaction behavior, it's essential to integrate your instrumentation with the transactional producers. This ensures accurate tracking and analysis of transactional activities, enhancing system monitoring and reliability. Refer to the [WaterDrop Transactions Instrumentation](WaterDrop-Transactions#instrumentation) section for a comprehensive approach to transaction instrumentation.
+Transactions Instrumentation is directly tied to the **producer** handling the transaction. To effectively monitor transaction behavior, integrate your instrumentation with the transactional producers. This ensures accurate tracking and analysis of transactional activities, enhancing system monitoring and reliability. Refer to the [WaterDrop Transactions Instrumentation](WaterDrop-Transactions#instrumentation) section for a comprehensive approach to transaction instrumentation.
 
-However, it's important to know that **consumer lag monitoring** for transactional consumers behaves differently. Since offsets are committed as part of the transaction by the producer rather than by the consumer, the usual consumer metrics (like `consumer_lag_stored`) will not be published or will show `-1` (or remain at whatever initial offset they had when subscribing). In other words, **consumer lag is not directly visible at the consumer level** because it's bypassing the consumer's offset manager.
+However, **consumer lag monitoring** for transactional consumers behaves differently. Since offsets are committed as part of the transaction by the producer rather than by the consumer, the usual consumer metrics (like `consumer_lag_stored`) will not be published or will show `-1` (or remain at whatever initial offset they had when subscribing). In other words, **consumer lag is not directly visible at the consumer level** because it's bypassing the consumer's offset manager.
 
 !!! warning "Consumer Lag Monitoring"
 
-    It's essential to be aware that **consumer lag monitoring** for transactional consumers behaves differently. Since offsets are committed as part of the transaction by the producer rather than by the consumer, the usual consumer metrics (like `consumer_lag_stored`) will not be published or will show `-1` (or remain at whatever initial offset they had when subscribing). In other words, **consumer lag is not directly visible at the consumer level** because it's bypassing the consumer's offset manager.
+    **Consumer lag monitoring** for transactional consumers behaves differently. Since offsets are committed as part of the transaction by the producer rather than by the consumer, the usual consumer metrics (like `consumer_lag_stored`) will not be published or will show `-1` (or remain at whatever initial offset they had when subscribing). In other words, **consumer lag is not directly visible at the consumer level** because it's bypassing the consumer's offset manager.
 
 ### Karafka Web UI
 
@@ -518,7 +518,7 @@ While Kafka transactions in Karafka provide strong consistency guarantees and da
 
 1. **Risk of Hanging Transactions**: Hanging transactions pose a significant risk, often resulting from inconsistencies between the replicas and the transaction coordinator. Historically, analyzing these situations has been challenging due to limited visibility into the producers' and transaction coordinators' states. However, Kafka provides tools to detect, analyze, and recover from hanging transactions, enhancing system stability and performance. You can read more about this issue [here](https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions).
 
-In summary, while Kafka transactions in Karafka provide significant data consistency and reliability benefits, they also introduce specific performance implications. It's essential to weigh these factors carefully when designing your system and implement monitoring and performance tuning to ensure that the system can handle the required load while maintaining the integrity of the transactions. Understanding and managing these implications can help balance consistency guarantees and system performance.
+In summary, while Kafka transactions in Karafka provide significant data consistency and reliability benefits, they also introduce specific performance implications. Weigh these factors carefully when designing your system and implement monitoring and performance tuning to ensure that the system can handle the required load while maintaining the integrity of the transactions. Understanding and managing these implications can help balance consistency guarantees and system performance.
 
 ## Example Use Cases
 
@@ -544,7 +544,7 @@ These scenarios illustrate the pivotal role of Karafka transactions in ensuring 
 
 ## Summary
 
-Karafka's Kafka transactions provide a robust mechanism for ensuring atomicity and consistency in distributed message processing. Handling produce and consume operations as a single unit prevents data loss or duplication, which is crucial for applications demanding strong consistency across partitions and topics.
+Karafka's Kafka transactions provide a mechanism for ensuring atomicity and consistency in distributed message processing. Handling produce and consume operations as a single unit prevents data loss or duplication, which is crucial for applications demanding strong consistency across partitions and topics.
 
 The framework supports Kafka's Exactly-Once Semantics, ensuring each message impacts the system state precisely once. This is crucial for operations like financial transactions or real-time analytics. However, performance implications like increased latency and resource demands must be considered.
 

--- a/Pro/Consumer-Groups/Virtual-Partitions.md
+++ b/Pro/Consumer-Groups/Virtual-Partitions.md
@@ -151,7 +151,7 @@ end
 
 !!! tip "Lazy Deserialization Advisory"
 
-    Keep in mind that Karafka provides [lazy deserialization](https://github.com/karafka/karafka/wiki/Consumer-Groups-Deserialization#lazy-deserialization). If you decide to use payload data, deserialization will happen in the main thread before the processing. That is why, unless needed, it is not recommended.
+    Karafka provides [lazy deserialization](https://github.com/karafka/karafka/wiki/Consumer-Groups-Deserialization#lazy-deserialization). If you decide to use payload data, deserialization will happen in the main thread before the processing. That is why, unless needed, it is not recommended.
 
 ### Partitioning Randomly
 
@@ -387,7 +387,7 @@ end
 
 ## Virtual Offset Management
 
-When Karafka consumes messages with Virtual Partitions, it uses Virtual Offset Management, which is built on top of the regular offset management mechanism. This innovative approach enables a significant reduction in potentially double-processed messages. By employing Virtual Offset Management, Karafka intelligently tracks the offsets of messages consumed in all the virtual partitions, ensuring that each message is consumed only once, regardless of errors. This powerful feature enhances the reliability and efficiency of message processing, eliminating the risk of duplicate processing and minimizing any associated complications, thereby enabling seamless and streamlined data flow within your system.
+When Karafka consumes messages with Virtual Partitions, it uses Virtual Offset Management, which is built on top of the regular offset management mechanism. This innovative approach enables a significant reduction in potentially double-processed messages. By employing Virtual Offset Management, Karafka intelligently tracks the offsets of messages consumed in all the virtual partitions, ensuring that each message is consumed only once, regardless of errors. This powerful feature enhances the reliability and efficiency of message processing, eliminating the risk of duplicate processing and minimizing any associated complications, thereby enabling streamlined data flow within your system.
 
 This feature operates on a few layers to provide as good warranties as possible while ensuring that each virtual partition can work independently. Below you can find a detailed explanation of each component making Virtual Offset Management.
 
@@ -407,7 +407,7 @@ Below you can find a few examples of how Karafka transforms messages marked as c
 
 When a message is marked as consumed, Karafka recognizes that all previous messages in that virtual partition have been processed as well, even if they were not explicitly marked as consumed.
 
-This functionality seamlessly integrates with collective marking to materialize the highest possible Kafka offset. With collective marking, Karafka can efficiently track the progress of message consumption across different virtual consumers.
+This functionality integrates with collective marking to materialize the highest possible Kafka offset. With collective marking, Karafka can efficiently track the progress of message consumption across different virtual consumers.
 
 Below you can find an example illustrating which of the messages will be virtually marked as consumed when given message in a virtual partition is marked.
 
@@ -564,7 +564,7 @@ end
 
 Karafka assigns each virtual partition a dedicated, long-lived consumer instance. This design ensures that messages within a virtual partition are processed consistently and independently from other partitions and that those consumers can implement things like accumulators and buffers. However, there is no fixed relationship between threads and consumer instances, allowing for flexible and efficient use of resources.
 
-One of Karafka's key strengths is the adaptability of its worker threads. Any available thread can run any consumer instance, a dynamic allocation that ensures efficient utilization of all available resources. This flexibility prevents idle threads, maximizing throughput. The dynamic nature of thread assignment also means that different threads can seamlessly pick up the work of a particular virtual partition between batches, giving users a sense of control.
+One of Karafka's key strengths is the adaptability of its worker threads. Any available thread can run any consumer instance, a dynamic allocation that ensures efficient utilization of all available resources. This flexibility prevents idle threads, maximizing throughput. The dynamic nature of thread assignment also means that different threads can pick up the work of a particular virtual partition between batches, giving users a sense of control.
 
 The assignment of messages to virtual partitions is consistent and based on a partitioner key. This key ensures that messages with the same key are consistently routed to the same virtual partition. Consequently, the same consumer instance processes these messages, maintaining the order and integrity required for reliable multi-batch message handling.
 
@@ -648,7 +648,7 @@ Karafka default [monitor](Infrastructure-Monitoring-and-Logging) and the Web UI 
 
 Both `#shutdown` and `#revoked` handlers work the same as within [regular consumers](Basics-Consuming-Messages#shutdown-and-partition-revocation-handlers).
 
-For each virtual consumer instance, both are executed when shutdown or revocation occurs. Please keep in mind that those are executed for **each** instance. That is, upon shutdown, if you used ten threads and they were all used with virtual partitions, the `#shutdown` method will be called ten times. Once per each virtual consumer instance that was in use.
+For each virtual consumer instance, both are executed when shutdown or revocation occurs. Those are executed for **each** instance. That is, upon shutdown, if you used ten threads and they were all used with virtual partitions, the `#shutdown` method will be called ten times. Once per each virtual consumer instance that was in use.
 
 <p align="center">
   <img src="https://karafka.io/assets/misc/charts/virtual_partitions/shutdown.svg" />

--- a/Pro/FAQ.md
+++ b/Pro/FAQ.md
@@ -66,7 +66,7 @@ Karafka is widely deployed across various organizations worldwide, including ind
 
 ### **Sustainable Commercial Backing**
 
-Unlike typical open-source projects that rely on volunteer maintenance, Karafka has a robust commercial model:
+Unlike typical open-source projects that rely on volunteer maintenance, Karafka has a commercial model:
 
 - **Karafka Pro** provides commercial licenses, priority support, and architecture consultations
 - Pro subscriptions directly fund ongoing research and development
@@ -291,7 +291,7 @@ Karafka and Karafka Pro are served directly from [RubyGems](https://rubygems.org
 
 We understand that some companies have strict policies regarding their open-source supply chain, and we are happy to provide a solution that meets those needs.
 
-Karafka can be used with an embedded/offline license without relying on our gem server. It is important to note that this mode of operation requires an Enterprise agreement.
+Karafka can be used with an embedded/offline license without relying on our gem server. This mode of operation requires an Enterprise agreement.
 
 Upon agreement, we will provide the license gem sources with installation instructions, so you can start using Karafka Pro with ease without reliance on our third-party source.
 
@@ -374,7 +374,7 @@ You can read more about those differences [here](Pro-Enterprise).
 
 With Karafka Pro priority support, you'll receive an initial assessment and reply within a maximum of **4 business days**. Enterprise customers receive even faster support with a maximum response time of **2 business days**. While most issues are diagnosed, reproduced, and fixed within seven days of the report acknowledgment, complex cases might take up to a few months. Every case is unique and addressed individually.
 
-Please note that our software is provided "as is." We recommend using the trial period to thoroughly test it, as we cannot guarantee it will be entirely bug-free or that all issues will be resolved. That said, we always strive to deliver the best, and historically, there have been no unresolved bugs. However, given Kafka's complexity, situations can vary.
+Our software is provided "as is." We recommend using the trial period to thoroughly test it, as we cannot guarantee it will be entirely bug-free or that all issues will be resolved. That said, we always strive to deliver the best, and historically, there have been no unresolved bugs. However, given Kafka's complexity, situations can vary.
 
 ## Where can I find a list of OSS components that the Karafka ecosystem uses?
 

--- a/Pro/HIPAA-PHI-PII-Support.md
+++ b/Pro/HIPAA-PHI-PII-Support.md
@@ -109,7 +109,7 @@ Although HIPAA, PHI, and PII regulations do not explicitly require the use of pr
 
 ## Summary
 
-Karafka and Karafka Web UI offer a secure and adaptable platform that can be configured to meet the stringent requirements of environments governed by HIPAA, PHI, and PII regulations. Key features such as at-rest and in-transit data encryption, role-based access control, granular data presentation, comprehensive logging, and configurable data access policies make Karafka a robust solution for managing sensitive data streams in compliance with privacy laws.
+Karafka and Karafka Web UI offer a secure and adaptable platform that can be configured to meet the stringent requirements of environments governed by HIPAA, PHI, and PII regulations. Key features such as at-rest and in-transit data encryption, role-based access control, granular data presentation, comprehensive logging, and configurable data access policies make Karafka a solution for managing sensitive data streams in compliance with privacy laws.
 
 For information about compliance certifications (SOC 2, ISO 27001) and why they do not apply to self-hosted software like Karafka, see our [Compliance Certifications documentation](Pro-Compliance-Certifications).
 

--- a/Pro/Iterator-API.md
+++ b/Pro/Iterator-API.md
@@ -1,4 +1,4 @@
-Iterator API allows developers to subscribe to Kafka topics and perform data lookups from various Ruby processes, including Rake tasks, custom scripts, and the Rails console. This API provides a powerful and flexible way to access Kafka data without the need for complex setup, configuration, `karafka server` processes deployment or creating consumers.
+Iterator API allows developers to subscribe to Kafka topics and perform data lookups from various Ruby processes, including Rake tasks, custom scripts, and the Rails console. This API provides a flexible way to access Kafka data without the need for complex setup, configuration, `karafka server` processes deployment or creating consumers.
 
 The Iterator API is designed to be simple and easy to use. It allows developers to subscribe to specific Kafka topics and partitions and perform data lookups using a simple and intuitive Ruby interface.
 
@@ -8,7 +8,7 @@ One of the major benefits of the Iterator API is its flexibility. You can use it
 
 !!! info "Iterator API and Compacted Messages"
 
-    When using Karafka's Iterator API to access Kafka data, please keep in mind, that it skips compacted messages and transactions-related messages during reading. However, these skipped messages are still included in the overall count. For instance, if you request the last 10 messages and all are transaction-related or compacted, the API will return no data, but they're counted in the total.
+    When using Karafka's Iterator API to access Kafka data, it skips compacted messages and transactions-related messages during reading. However, these skipped messages are still included in the overall count. For instance, if you request the last 10 messages and all are transaction-related or compacted, the API will return no data, but they're counted in the total.
 
 ## Usage
 
@@ -194,7 +194,7 @@ end
 
 !!! tip "Recommended Approach for Long-Living Iterators"
 
-    If you find yourself working with long-living iterators that operate for a long time, we do recommend using the `karafka server` default consumption API as it provides all the needed features and components for robust and long-running consumption.
+    If you find yourself working with long-living iterators that operate for a long time, we do recommend using the `karafka server` default consumption API as it provides all the needed features and components for long-running consumption.
 
 ### EOF and Termination Semantics
 
@@ -275,7 +275,7 @@ end
 
 The [Cleaner API](Pro-Cleaner-API) is designed to enhance batch processing efficiency by promptly freeing up memory once a message's payload is no longer needed. This functionality is especially beneficial when working with large payloads (10KB and above) and can help manage memory usage more effectively.
 
-The Cleaner API can be integrated with the Iterator API to ensure optimal memory management during long-running iterations. When processing large datasets or streaming data over extended periods, it is essential to keep memory usage under control to avoid performance degradation or crashes due to memory overload.
+The Cleaner API can be integrated with the Iterator API to ensure optimal memory management during long-running iterations. When processing large datasets or streaming data over extended periods, keep memory usage under control to avoid performance degradation or crashes due to memory overload.
 
 Here's how you can use the Cleaner API with the Iterator API to process messages and clean up memory efficiently:
 
@@ -299,13 +299,13 @@ In this example, the `#clean!` method is called on each message after processing
 
 The Karafka Pro Iterator API is designed to be simple and easy to use, and there is nothing special needed to get started with it. There are also no special recommendations when using it from any specific Ruby process type.
 
-However, it is important to remember that the Iterator API is designed for lightweight Kafka operations and should not be used to perform extensive Kafka operations during HTTP requests or similar. This is because performing extensive Kafka operations during requests can impact the application's performance and result in slower response times.
+However, the Iterator API is designed for lightweight Kafka operations and should not be used to perform extensive Kafka operations during HTTP requests or similar. This is because performing extensive Kafka operations during requests can impact the application's performance and result in slower response times.
 
-Additionally, it is important to note that the Iterator API does not manage the offsets. This means that when you subscribe to a Kafka topic and partition, you must provide the initial offsets yourself.
+Additionally, the Iterator API does not manage the offsets. This means that when you subscribe to a Kafka topic and partition, you must provide the initial offsets yourself.
 
 ### Scalability and Performance
 
-It's important to note that the Karafka Pro iterator API is designed to be a straightforward way to access Kafka data using Ruby. However, it is a single-threaded API, meaning it does not provide any form of parallelizing data. This means that any data processing or analysis will be performed sequentially, which may impact performance when dealing with large amounts of data or performing extensive IO operations. While this can be limiting in some cases, the Iterator API's simplicity and ease of use make it an attractive option for developers looking for a quick and easy way to access Kafka data without the need for complex configuration or deployment of additional processes. If parallelization is required, alternative approaches, such as using the Karafka consumers feature, may need to be explored.
+The Karafka Pro iterator API is designed to be a straightforward way to access Kafka data using Ruby. However, it is a single-threaded API, meaning it does not provide any form of parallelizing data. This means that any data processing or analysis will be performed sequentially, which may impact performance when dealing with large amounts of data or performing extensive IO operations. While this can be limiting in some cases, the Iterator API's simplicity and ease of use make it an attractive option for developers looking for a quick and easy way to access Kafka data without the need for complex configuration or deployment of additional processes. If parallelization is required, alternative approaches, such as using the Karafka consumers feature, may need to be explored.
 
 The iterator should handle up to 100 000 messages per second.
 
@@ -372,7 +372,7 @@ end
 
 ## Summary
 
-Overall, the Karafka Pro Iterator API provides a powerful and flexible way to access and process Kafka data from various Ruby processes. Its simplicity, flexibility, and scalability make it an essential tool for developers who need to work with Kafka data quickly and efficiently.
+Overall, the Karafka Pro Iterator API provides a flexible way to access and process Kafka data from various Ruby processes. Its simplicity, flexibility, and scalability make it an essential tool for developers who need to work with Kafka data quickly and efficiently.
 
 ## See Also
 

--- a/Pro/Recurring-Tasks.md
+++ b/Pro/Recurring-Tasks.md
@@ -32,7 +32,7 @@ One key advantage of Recurring Tasks is its independence from external databases
 
 Karafka ensures that only one process executes tasks by using Kafka's partition assignment. Only the process assigned to the relevant topic executes the tasks, guaranteeing that different processes don't run them multiple times. This provides strong execution warranties, ensuring each task runs only once at a scheduled time.
 
-In case of a process crash, Kafka automatically reassigns the partitions to another available consumer. The new process takes over task execution immediately, continuing from where the previous process left off. This automatic failover ensures high availability and seamless task execution continuity, even during unexpected failures.
+In case of a process crash, Kafka automatically reassigns the partitions to another available consumer. The new process takes over task execution immediately, continuing from where the previous process left off. This automatic failover ensures high availability and task execution continuity, even during unexpected failures.
 
 ## Using Recurring Tasks
 
@@ -83,7 +83,7 @@ This will automatically create a special consumer group dedicated to the consump
 
 !!! tip "Review Replication Factor Configuration"
 
-    Before deploying to production, it is crucial to read the [Replication Factor Configuration for the Production Environment](Pro-Recurring-Tasks#replication-factor-configuration-for-the-production-environment) section. Ensuring the correct replication factor is set is vital for maintaining your Kafka topics' high availability and fault tolerance.
+    Before deploying to production, read the [Replication Factor Configuration for the Production Environment](Pro-Recurring-Tasks#replication-factor-configuration-for-the-production-environment) section. Ensuring the correct replication factor is set is vital for maintaining your Kafka topics' high availability and fault tolerance.
 
 When `recurring_tasks(true)` is invoked, this command will automatically create appropriate entries for Karafka [Declarative Topics](Infrastructure-Declarative-Topics). This means that all you need to do is to run the:
 
@@ -414,7 +414,7 @@ expect { cleanup_task.execute }.not_to raise_error
 
 ## Warranties
 
-Recurring Tasks provides strong execution warranties by using Kafka’s robust architecture. With Kafka as the backbone, tasks are guaranteed to execute only once at their scheduled time, managed by the process that holds the partition assignment for the relevant topic.
+Recurring Tasks provides strong execution warranties by using Kafka’s architecture. With Kafka as the backbone, tasks are guaranteed to execute only once at their scheduled time, managed by the process that holds the partition assignment for the relevant topic.
 
 - **Single Process Execution**: Karafka ensures that only one process can execute the scheduled tasks by assigning Kafka partitions to a single consumer. This prevents multiple processes from executing the same task simultaneously, offering a strong guarantee of task uniqueness and timing precision.
 
@@ -442,7 +442,7 @@ Recurring Tasks provides strong execution warranties by using Kafka’s robust a
 
 - **Regulatory Compliance and Auditing**: Schedule regular tasks to automatically generate and store compliance reports, ensuring your organization meets audit requirements without manual intervention.
 
-- **Data Pipeline Orchestration**: Coordinate complex data processing pipelines by triggering different stages of ETL (Extract, Transform, Load) processes at scheduled intervals, ensuring that data flows seamlessly from one stage to the next.
+- **Data Pipeline Orchestration**: Coordinate complex data processing pipelines by triggering different stages of ETL (Extract, Transform, Load) processes at scheduled intervals, ensuring that data flows from one stage to the next.
 
 - **SLA-Based Monitoring and Alerts**: Monitor service-level agreements (SLAs) by scheduling checks that ensure critical metrics are within acceptable thresholds. Automatically trigger alerts or remediation actions if SLAs are breached.
 

--- a/Pro/Routing-Patterns.md
+++ b/Pro/Routing-Patterns.md
@@ -1,4 +1,4 @@
-Karafka's Routing Patterns is a powerful feature that offers flexibility in routing messages from various topics, including topics created during the runtime of Karafka processes. This feature allows you to use regular expression (regexp) patterns in routes. When a matching Kafka topic is detected, Karafka will automatically expand the routing and start consumption without additional configuration. This feature greatly simplifies the management of dynamically created Kafka topics.
+Karafka's Routing Patterns is a feature that offers flexibility in routing messages from various topics, including topics created during the runtime of Karafka processes. This feature allows you to use regular expression (regexp) patterns in routes. When a matching Kafka topic is detected, Karafka will automatically expand the routing and start consumption without additional configuration. This feature greatly simplifies the management of dynamically created Kafka topics.
 
 ## How It Works
 
@@ -16,7 +16,7 @@ Below, you can find a conceptual diagram of how the discovery process works:
   </small>
 </p>
 
-Upon detecting a new topic, Karafka seamlessly integrates its operations just as with pre-existing ones. Notably, regexp patterns identify topics even during application initialization, ensuring compatibility with topics established prior, provided they haven't been previously defined in the routes.
+Upon detecting a new topic, Karafka integrates its operations just as with pre-existing ones. Notably, regexp patterns identify topics even during application initialization, ensuring compatibility with topics established prior, provided they haven't been previously defined in the routes.
 
 !!! warning "Regexp Implementation Differences"
 
@@ -192,7 +192,7 @@ While this pattern looks complex, it works by explicitly matching any string tha
 
 ### Testing Exclusion Patterns
 
-Given the complexity of these patterns and the differences between Ruby and POSIX regex engines, it's crucial to test your exclusion patterns thoroughly:
+Given the complexity of these patterns and the differences between Ruby and POSIX regex engines, test your exclusion patterns thoroughly:
 
 ```ruby
 # The regex pattern that excludes "activities.data_results"
@@ -240,7 +240,7 @@ end
 
 ### When to Use Exclusion Patterns
 
-While exclusion patterns provide a powerful way to route messages, they should be used carefully:
+While exclusion patterns provide a way to route messages, they should be used carefully:
 
 - They're ideal when you need different Karafka-level configurations (like virtual partitions or specific error handling) for different topics
 - They simplify routing logic by keeping it at the configuration level instead of embedding it in consumer code
@@ -333,7 +333,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-To prevent such loops, it's essential to:
+To prevent such loops:
 
 - Craft regular expressions precisely, ensuring they match only the intended topics and not the DLQs unless explicitly desired.
 
@@ -341,11 +341,11 @@ To prevent such loops, it's essential to:
 
 - Test regular expressions thoroughly against various topic names as described [here](#testing-regular-expressions).
 
-While routing patterns offer a dynamic and powerful method to manage topic consumption in Karafka, they demand careful consideration and testing, especially when integrating DLQ mechanisms.
+While routing patterns offer a dynamic method to manage topic consumption in Karafka, they demand careful consideration and testing, especially when integrating DLQ mechanisms.
 
 ## Regexp Implementation Differences
 
-When dealing with regular expressions in Karafka, it's important to understand the underlying differences between the regex engines involved. The engine used depends on your rebalance protocol:
+When dealing with regular expressions in Karafka, understand the underlying differences between the regex engines involved. The engine used depends on your rebalance protocol:
 
 - **Classic protocol**: `librdkafka` evaluates regexes locally using the **POSIX regex engine** provided by `libc`.
 - **Consumer protocol (KIP-848)**: Regex evaluation is performed on the **broker side** using the **Google RE2/J** engine.

--- a/Pro/Scheduled-Messages.md
+++ b/Pro/Scheduled-Messages.md
@@ -6,9 +6,9 @@ Conceptually, it works in a similar way to the [ETF1 Kafka Message Scheduler](ht
 
 Karafka's Scheduled Messages feature provides a straightforward approach to scheduling Kafka messages for future delivery, allowing users to set precise timings for when messages should reach the desired topics. Using a specialized API, Karafka allows users to easily specify the delivery time for messages without having to handle the complex scheduling details directly. This is achieved by wrapping the messages in an envelope that includes all necessary scheduling information and dispatching them to a special "in-the-middle" topic, which is then managed automatically by Karafka.
 
-Each day at midnight, Karafka's scheduler, a dedicated consumer, reloads and scans a specific Kafka topic designated for storing scheduled messages. This routine includes loading new messages meant for the day, ensuring they are ready for dispatch at specified times. To maintain a seamless and continuous operation, the scheduler dispatches messages at regular intervals, typically every 15 seconds, which is configurable. This ensures that all scheduled messages are delivered when needed.
+Each day at midnight, Karafka's scheduler, a dedicated consumer, reloads and scans a specific Kafka topic designated for storing scheduled messages. This routine includes loading new messages meant for the day, ensuring they are ready for dispatch at specified times. To maintain a continuous operation, the scheduler dispatches messages at regular intervals, typically every 15 seconds, which is configurable. This ensures that all scheduled messages are delivered when needed.
 
-One key aspect of Karafka's handling of scheduled messages is its treatment of message payloads. It ensures the payload and user headers remain untouched by simply proxy-passing them with added trace headers.
+One key aspect of Karafka's handling of scheduled messages is its treatment of message payloads. It ensures the payload and user headers remain untouched by proxy-passing them with added trace headers.
 
 <p align="center">
   <img src="https://karafka.io/assets/misc/charts/scheduled_messages/flow.svg" />
@@ -293,7 +293,7 @@ This call places the wrapped message into the designated scheduling topic, which
 
 ### Message Key Uniqueness and Ordering Management
 
-When using this feature, it is crucial to understand dispatched messages keys and their uniqueness operations. Each message sent to the scheduler must have a distinct key within its partition to ensure accurate scheduling and prevent any potential overlaps or errors during the dispatch process.
+When using this feature, understand dispatched messages keys and their uniqueness operations. Each message sent to the scheduler must have a distinct key within its partition to ensure accurate scheduling and prevent any potential overlaps or errors during the dispatch process.
 
 By default, Karafka generates a unique key for each scheduled message envelope. This key is a combination of the topic to which the message will eventually be dispatched and a UUID. The formula used is something akin to: "{target_topic}-{UUID}". This key is then assigned to the `:key` field in the envelope, ensuring that each message is uniquely identified within the scheduling system.
 
@@ -367,7 +367,7 @@ The unique key is critical in the cancellation process for several reasons:
 
 !!! tip "Custom Keys and Automatic Key Generation"
 
-    When scheduling a message, if you choose to use a custom key or rely on the automatically generated key by Karafka, it's important to use the same key consistently for both scheduling and canceling the message. This consistency helps prevent errors and ensures that the correct message is targeted for cancellation.
+    When scheduling a message, if you choose to use a custom key or rely on the automatically generated key by Karafka, use the same key consistently for both scheduling and canceling the message. This consistency helps prevent errors and ensures that the correct message is targeted for cancellation.
 
 !!! tip "Handling Cancellations with `partition_key`"
 
@@ -409,7 +409,7 @@ To update the scheduled message:
 
 ## Monitoring and Metrics
 
-Karafka's Scheduled Messages feature integrates with standard monitoring tools provided by Karafka and its Web UI, allowing for visibility into the system's performance and behavior. It is, however, important to understand how this feature consumer may deviate from the standard consumer behaviors.
+Karafka's Scheduled Messages feature integrates with standard monitoring tools provided by Karafka and its Web UI, allowing for visibility into the system's performance and behavior. However, understand how this feature consumer may deviate from the standard consumer behaviors.
 
 Karafka treats scheduled messages like any other messages within its ecosystem:
 
@@ -467,7 +467,7 @@ Additionally, the Web UI offers a detailed exploration of scheduled messages, sh
 
 ## Error Handling and Retries
 
-This feature is designed to ensure robust error handling and efficient retry mechanisms, minimizing the potential impact of errors on scheduled message dispatches. Here's an overview of how error handling and retries are managed:
+This feature is designed to ensure error handling and efficient retry mechanisms, minimizing the potential impact of errors on scheduled message dispatches. Here's an overview of how error handling and retries are managed:
 
 **Key Points on Error Handling:**
 
@@ -495,7 +495,7 @@ This feature's error handling and retry strategies ensure that the system remain
 
 ## Warranties
 
-Karafka's Scheduled Messages feature offers a set of warranties designed to ensure robust functionality and reliability within production environments. Here's a summary of the key guarantees and limitations:
+Karafka's Scheduled Messages feature offers a set of warranties designed to ensure functionality and reliability within production environments. Here's a summary of the key guarantees and limitations:
 
 - **Message Delivery Guarantee**: Karafka ensures that all scheduled messages will be delivered at least once, minimizing the risk of message loss. However, messages might be delivered multiple times under certain circumstances like network or Kafka cluster disruptions.
 
@@ -517,7 +517,7 @@ When using a transactional WaterDrop producer, the Scheduled Messages feature ca
 
 ## Limitations
 
-While Scheduled Messages offer powerful message scheduling and dispatch capabilities, users should be aware of inherent limitations when integrating this feature into their systems. Understanding these limitations can help you plan and optimize scheduled messages usage within your applications.
+While Scheduled Messages offer message scheduling and dispatch capabilities, users should be aware of inherent limitations when integrating this feature into their systems. Understanding these limitations can help you plan and optimize scheduled messages usage within your applications.
 
 1. **Single Delivery Point**: Scheduled messages are designed to be delivered to a specific topic at a predetermined time. Once a message is scheduled, redirecting it to a different topic at runtime is not supported. Message dispatch can be canceled, though.
 
@@ -561,7 +561,7 @@ Given this feature's unique operational characteristics, particularly its data-l
 
 - **Dedicated Instances**: Consider deploying the scheduled messages feature on dedicated instances or containers. This approach allows for tailored resource allocation, such as CPU, memory, and network bandwidth, which can be adjusted based on the specific demands of the scheduling tasks without affecting other services.
 
-- **Monitoring and Scaling**: Implement robust monitoring to track the performance and resource utilization of the scheduled messages feature. This monitoring should focus on memory usage, CPU load, and network traffic metrics. Based on these metrics, apply auto-scaling policies where feasible to handle variations in load, especially those that are predictable based on the scheduling patterns.
+- **Monitoring and Scaling**: Implement monitoring to track the performance and resource utilization of the scheduled messages feature. This monitoring should focus on memory usage, CPU load, and network traffic metrics. Based on these metrics, apply auto-scaling policies where feasible to handle variations in load, especially those that are predictable based on the scheduling patterns.
 
 - **Avoid Frequent Redeploys**: Minimize the frequency of redeployments for the components handling scheduled messages. Frequent restarts can disrupt the scheduling process, especially if they occur during daily data reloads.
 
@@ -573,7 +573,7 @@ Given this feature's unique operational characteristics, particularly its data-l
 
 Karafka's Scheduled Messages feature is designed with flexibility, allowing integration with external producers beyond Karafka and WaterDrop. This enables scheduled messages to be dispatched from various technologies, including Go, JavaScript, or any other language and framework that supports Kafka producers.
 
-When using external producers to schedule messages, it's crucial to follow a specific header format to ensure Karafka's scheduled message consumer can recognize and correctly process these messages. The required headers are as follows:
+When using external producers to schedule messages, follow a specific header format to ensure Karafka's scheduled message consumer can recognize and correctly process these messages. The required headers are as follows:
 
 - `schedule_schema_version`: Indicates the version of the scheduling schema used, which helps manage compatibility. For current implementations, this should be set to 1.0.0.
 
@@ -632,7 +632,7 @@ Use Cases:
 
 - Flexibility to create multiple time delays for different types of messages.
 - Allows you to group delayed messages into "buckets" based on their time requirements.
-- Seamless integration of delayed processing with piping ensures that messages are forwarded to their final destination once their delay expires.
+- Integration of delayed processing with piping ensures that messages are forwarded to their final destination once their delay expires.
 - Simplifies complex workflows that require messages to be processed after various time intervals.
 
 **Cons**:


### PR DESCRIPTION
Second readability pass, extending PR #793's approach to the Pro feature pages (the largest remaining offender cluster). Applies the rules documented in Development/Technical-Writing.md (lines 72-74): cut throat-clearing openers, delete minimizing filler, and remove empty marketing words where they carry no information.

70 changes across 14 Pro pages (Consumer-Groups: Transactions, Filtering-API, Delayed-Topics, Virtual-Partitions, Periodic-Jobs, Multiplexing, Scheduling-API, Offset-Metadata-Storage; plus Scheduled-Messages, Iterator-API, Routing-Patterns, FAQ, Recurring-Tasks, HIPAA-PHI-PII-Support).

Judgment-based, not mechanical: load-bearing words were kept (substantiated 'powerful tool', 'robustness' nouns, 'comprehensive'/'robust' in the compliance context, genuine 'simple'/'simply'/'essential' adjectives), and 'Remember that' was preserved to keep the conversational voice. Code, links, headings, and admonition titles were left untouched.

Verified: npm run lint clean, ./bin/mklint strict build passes, every link/anchor target and inline-code span byte-identical, and all bold emphasis balanced.