### PR TITLE
docs: finish the readability sweep across remaining pages (part 4)

### DIFF
--- a/Basics/Components.md
+++ b/Basics/Components.md
@@ -1,4 +1,4 @@
-Karafka is a robust, Ruby-based framework for building Kafka-driven applications. It provides a comprehensive suite of tools for message production, consumption, and monitoring within Apache Kafka environments. The ecosystem consists of several specialized components:
+Karafka is a Ruby-based framework for building Kafka-driven applications. It provides a suite of tools for message production, consumption, and monitoring within Apache Kafka environments. The ecosystem consists of several specialized components:
 
 - **[Karafka](https://github.com/karafka/karafka)** - core framework that handles message consumption from Kafka topics with advanced routing and processing capabilities
 - **[WaterDrop](https://github.com/karafka/waterdrop)** - dedicated message production library optimized for high-performance and reliable delivery to Kafka clusters

--- a/Basics/Consuming-Messages.md
+++ b/Basics/Consuming-Messages.md
@@ -190,7 +190,7 @@ To configure the initial offset for specific topics:
 
 When working with a distributed system like Kafka, topic partitions can be distributed among different consumers in a consumer group for processing. However, there are cases where a partition needs to be removed from one consumer and reassigned to another. This process is known as a partition revocation.
 
-Partition revocation can be voluntary, where a consumer willingly gives up the partition after processsing the current batch, or it can be involuntary. Involuntary partition revocation usually happens due to events such as a rebalance triggered by changes in the consumer group or a failure of a consumer that makes it unresponsive.  It is important to remember that involuntary revocations can occur during data processing. if you are aware that a partition has been removed, you may not want to continue processing messages. This is where the `#revoked?` method is beneficial.
+Partition revocation can be voluntary, where a consumer willingly gives up the partition after processsing the current batch, or it can be involuntary. Involuntary partition revocation usually happens due to events such as a rebalance triggered by changes in the consumer group or a failure of a consumer that makes it unresponsive.  Involuntary revocations can occur during data processing. if you are aware that a partition has been removed, you may not want to continue processing messages. This is where the `#revoked?` method is beneficial.
 
 By monitoring the status of the `#revoked?` method, your application can detect that your process no longer owns a partition you are operating on. In such cases, you can choose to stop any ongoing, expensive processing. This can help you save resources and reduce the number of potential reprocessings.
 
@@ -208,7 +208,7 @@ def consume
 end
 ```
 
-It is worth noting, however, that under normal operating conditions, Karafka will complete all ongoing processing before a rebalance occurs. This includes finishing the processing of all messages already fetched. Karafka has built-in mechanisms to handle voluntary partition revocations and rebalances, ensuring that no messages are lost or unprocessed during such events. Hence, `#revoked?` is especially useful for involuntary revocations.
+However, under normal operating conditions, Karafka will complete all ongoing processing before a rebalance occurs. This includes finishing the processing of all messages already fetched. Karafka has built-in mechanisms to handle voluntary partition revocations and rebalances, ensuring that no messages are lost or unprocessed during such events. Hence, `#revoked?` is especially useful for involuntary revocations.
 
 In most cases, especially if you do not use [Long-Running Jobs](Pro-Consumer-Groups-Long-Running-Jobs), the Karafka default [offset management](Consumer-Groups-Offset-management) strategy should be more than enough. It ensures that, after batch processing and upon rebalances, all offsets are committed before partition reassignment. In a healthy system with stable deployment procedures and without frequent short-lived consumer generations, the number of re-processings should be close to zero.
 
@@ -421,7 +421,7 @@ For more details on this feature, see [Iterator API](Pro-Iterator-API).
 
 ## Avoiding Accidental Overwriting of Consumer Instance Variables
 
-When working with Karafka consumers, it is essential to be mindful of certain instance variables used by the consumer instances. Unintentionally overwriting these variables can lead to critical processing errors and result in issues, such as `worker.process.error`, which can be seen in the Karafka Web UI. The following are the primary instance variables that you should be careful about:
+When working with Karafka consumers, be mindful of certain instance variables used by the consumer instances. Unintentionally overwriting these variables can lead to critical processing errors and result in issues, such as `worker.process.error`, which can be seen in the Karafka Web UI. The following are the primary instance variables that you should be careful about:
 
 - `@id`: Consumer instance identifier
 - `@messages`: Messages batch for the subscribed topic

--- a/Basics/FAQ/Web-UI.md
+++ b/Basics/FAQ/Web-UI.md
@@ -120,7 +120,7 @@ The reason for this approach is grounded in practicality and long-term maintaina
 
 To put it in perspective:
 
-- **Maintenance Cost & Commitment**: Introducing such a feature would mean an ongoing commitment to ensuring it works seamlessly with every subsequent update or change to Karafka or Datadog. It's imperative to consider the long-term cost of this commitment.
+- **Maintenance Cost & Commitment**: Introducing such a feature would mean an ongoing commitment to ensuring it works with every subsequent update or change to Karafka or Datadog. It's imperative to consider the long-term cost of this commitment.
 
 - **External Dependencies**: If Datadog's release cycle or features were to evolve unexpectedly, it could lead to complexities in ensuring smooth integration. This introduces an external dependency that's out of Karafka's direct control.
 

--- a/Basics/Producing-Messages.md
+++ b/Basics/Producing-Messages.md
@@ -38,7 +38,7 @@ For more details on how to use the WaterDrop producer and its various message pr
 
 ## Messages Piping
 
-If you are looking for seamless message piping in Kafka-based systems, see [Piping](Pro-Consumer-Groups-Piping) to get familiar with the message piping feature exclusive to Karafka Pro. This feature offers synchronous and asynchronous forwarding capabilities with enhanced traceability, which is perfect for streamlining data workflows.
+If you are looking for message piping in Kafka-based systems, see [Piping](Pro-Consumer-Groups-Piping) to get familiar with the message piping feature exclusive to Karafka Pro. This feature offers synchronous and asynchronous forwarding capabilities with enhanced traceability, which is perfect for streamlining data workflows.
 
 ## Producer Shutdown
 
@@ -56,7 +56,7 @@ In the following sections, you can find an example of how to `#close` the produc
 
 !!! warning "Do Not Manually Close the Producer When Embedding"
 
-    Note, that you should **not** close the producer manually if you are using the [Embedding API](Infrastructure-Embedding) in the same process.
+    You should **not** close the producer manually if you are using the [Embedding API](Infrastructure-Embedding) in the same process.
 
 ### Closing Producer Used in Karafka
 
@@ -231,6 +231,6 @@ By using this flexibility in Karafka, you can effectively manage and direct mess
 
 - [Usage](WaterDrop-Usage) - Comprehensive guide to using WaterDrop for message production
 - [Transactions](WaterDrop-Transactions) - Implement exactly-once semantics with transactional producers
-- [Piping](Pro-Consumer-Groups-Piping) - Seamlessly forward messages between Kafka topics with enhanced traceability
+- [Piping](Pro-Consumer-Groups-Piping) - Forward messages between Kafka topics with enhanced traceability
 - [Multi Cluster Setup](Infrastructure-Multi-Cluster-Setup) - Configure and produce to multiple Kafka clusters simultaneously
 - [Consuming Messages](Basics-Consuming-Messages) - Learn how to consume the messages you produce

--- a/Basics/Support.md
+++ b/Basics/Support.md
@@ -12,7 +12,7 @@
 
 Karafka's Open Source Software (OSS) support primarily revolves around assisting users with issues related to the Karafka and librdkafka ecosystems. This involves troubleshooting and providing solutions for problems originating from Karafka or its related subcomponents.
 
-However, it is crucial to understand that the OSS support does **not** extend to application-specific issues that do not originate from Karafka or its related parts. This includes but is not limited to:
+However, the OSS support does **not** extend to application-specific issues that do not originate from Karafka or its related parts. This includes but is not limited to:
 
 1. Incorrect application configurations unrelated to Karafka.
 2. Conflicts with other libraries or frameworks within your application.

--- a/Consumer-Groups/Concurrency-and-Multithreading.md
+++ b/Consumer-Groups/Concurrency-and-Multithreading.md
@@ -9,7 +9,7 @@ Additionally, Karafka supports [Swarm Mode](Infrastructure-Swarm-Multi-Process) 
 
 !!! tip "Separate Resources Management Documentation"
 
-    Please be aware that detailed information on how Karafka manages resources such as threads and TCP connections can be found on a separate documentation page titled [Resources Management](Infrastructure-Resources-Management). This page provides comprehensive insights into the allocation and optimization of system resources by Karafka components.
+    Please be aware that detailed information on how Karafka manages resources such as threads and TCP connections can be found on a separate documentation page titled [Resources Management](Infrastructure-Resources-Management). This page provides insights into the allocation and optimization of system resources by Karafka components.
 
 ## Parallel Messages Processing
 

--- a/Consumer-Groups/Deserialization.md
+++ b/Consumer-Groups/Deserialization.md
@@ -203,7 +203,7 @@ Lazy deserialization provides following benefits:
 
 - **Flexibility and Control**: Developers have more control over when and how data is processed, allowing for customized handling based on the content of the messages.
 
-Lazy deserialization in Karafka provides a robust mechanism for managing data processing in a Kafka-based messaging environment. It ensures that applications remain efficient and responsive even as data volume and complexity grow.
+Lazy deserialization in Karafka provides a mechanism for managing data processing in a Kafka-based messaging environment. It ensures that applications remain efficient and responsive even as data volume and complexity grow.
 
 ## Handling of Tombstone Messages
 
@@ -281,7 +281,7 @@ This approach simplifies the management of topics and makes the deserialization 
 
 ## Apache Avro
 
-[Apache Avro](https://avro.apache.org/) is a data serialization system developed by the Apache Foundation, used widely in the Big Data and cloud computing field. It provides a compact, fast, binary data format with rich data structures. Its schema evolution capability allows for flexibility in data reading and writing, with old software being able to read new data and vice versa. This language-agnostic system aids efficient data interchange between programs and supports a seamless and efficient way of data storage, encoding, and decoding.
+[Apache Avro](https://avro.apache.org/) is a data serialization system developed by the Apache Foundation, used widely in the Big Data and cloud computing field. It provides a compact, fast, binary data format with rich data structures. Its schema evolution capability allows for flexibility in data reading and writing, with old software being able to read new data and vice versa. This language-agnostic system aids efficient data interchange between programs and supports an efficient way of data storage, encoding, and decoding.
 
 From the perspective of the Karafka framework, Avro is a serialization and deserialization layer, and there are no special things that are required to use it aside from making sure that you both serialize and deserialize your data using it.
 

--- a/Consumer-Groups/Inline-Insights.md
+++ b/Consumer-Groups/Inline-Insights.md
@@ -63,7 +63,7 @@ end
 
 ## Insights Runtime Availability
 
-Upon establishing a connection with Kafka, it is essential to understand that metrics related to Inline Insights might not be immediately accessible. This delay is attributed to the way Karafka fetches and computes these metrics. By default, the metrics are calculated at intervals of 5 seconds.
+Upon establishing a connection with Kafka, metrics related to Inline Insights might not be immediately accessible. This delay is attributed to the way Karafka fetches and computes these metrics. By default, the metrics are calculated at intervals of 5 seconds.
 
 Furthermore, depending on the version of Kafka you are using and other underlying factors, the availability of insights, especially during the first batch processing, may vary. This means that for a brief period after connecting, your consumers might not be insight-aware and insights will be empty.
 
@@ -143,4 +143,4 @@ Karafka's Inline Insights is a powerful feature that enhances data processing ca
 ## See Also
 
 - [Pro Enhanced Inline Insights](Pro-Consumer-Groups-Enhanced-Inline-Insights) - Advanced inline insights with enhanced metrics and performance tracking
-- [Monitoring and Logging](Infrastructure-Monitoring-and-Logging) - Comprehensive monitoring and logging strategies for Karafka applications
+- [Monitoring and Logging](Infrastructure-Monitoring-and-Logging) - Monitoring and logging strategies for Karafka applications

--- a/Consumer-Groups/Persistent-Pausing.md
+++ b/Consumer-Groups/Persistent-Pausing.md
@@ -2,7 +2,7 @@
 
 !!! info "Future Web UI Enhancement"
 
-    Persistent pausing support in Karafka Web UI is planned, but there is no ETA for it yet. This is a complex feature that requires careful consideration of distributed state management, rebalancing scenarios, and API design to ensure it works reliably across different deployment architectures. Until then, the Filtering API approach described below provides a robust solution for persistent pausing needs.
+    Persistent pausing support in Karafka Web UI is planned, but there is no ETA for it yet. This is a complex feature that requires careful consideration of distributed state management, rebalancing scenarios, and API design to ensure it works reliably across different deployment architectures. Until then, the Filtering API approach described below provides a solution for persistent pausing needs.
 
 Karafka's [Web UI pausing](Pro-Web-UI-Commanding#pause-and-resume-partitions) is **not** persistent - it's designed for emergency "oh gosh, there's a bug" scenarios where you need immediate, temporary relief. When the process restarts or rebalances, Web UI pauses are lost.
 
@@ -93,7 +93,7 @@ end
 
 !!! warning "Keep Pause Check Intervals Reasonable"
 
-    When implementing persistent pausing with filters, it's crucial to keep the `PAUSE_DURATION` (check interval) relatively short - typically around 60 seconds is recommended. This is because when a partition is paused, librdkafka does not refresh its metadata, so lag statistics and other metrics will not update in real time until the partition is resumed.
+    When implementing persistent pausing with filters, keep the `PAUSE_DURATION` (check interval) relatively short - typically around 60 seconds is recommended. This is because when a partition is paused, librdkafka does not refresh its metadata, so lag statistics and other metrics will not update in real time until the partition is resumed.
 
     **Avoid long pause check intervals** (e.g., 10-20 minutes or more) as this will:
 

--- a/Consumer-Groups/Routing.md
+++ b/Consumer-Groups/Routing.md
@@ -137,7 +137,7 @@ end
 
 ### Routing Patterns
 
-For users using the advanced capabilities of Karafka Pro, the Routing Patterns feature has its dedicated documentation page. This page delves deep into the behavior, configuration, and best practices surrounding Routing Patterns. Please refer to the [Routing Patterns documentation](Pro-Routing-Patterns) to explore this feature in detail and gain comprehensive insights.
+For users using the advanced capabilities of Karafka Pro, the Routing Patterns feature has its dedicated documentation page. This page delves deep into the behavior, configuration, and best practices surrounding Routing Patterns. Please refer to the [Routing Patterns documentation](Pro-Routing-Patterns) to explore this feature in detail and gain insights.
 
 ## Overriding Defaults
 
@@ -183,7 +183,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-When you decide to override any default option for a topic within the `#topic` block, it's crucial to understand that you must set **all** the arguments for that particular option. Partial updating of arguments is not supported.
+When you decide to override any default option for a topic within the `#topic` block, you must set **all** the arguments for that particular option. Partial updating of arguments is not supported.
 
 Karafka will not use the user-specified defaults you've defined in the defaults block if you attempt to update the arguments for an option partially. Instead, it will revert to the framework's internal defaults for the missing arguments. This could lead to unexpected behavior in your application if not considered.
 
@@ -354,7 +354,7 @@ Karafka.routing.draw do
 end
 ```
 
-By using the ability to draw routes multiple times, Karafka seamlessly fits into a Modular Monolith architecture. This allows for improved code organization, easier maintenance, and the flexibility to evolve each module independently.
+By using the ability to draw routes multiple times, Karafka fits into a Modular Monolith architecture. This allows for improved code organization, easier maintenance, and the flexibility to evolve each module independently.
 
 ## See Also
 

--- a/Development/SBOM.md
+++ b/Development/SBOM.md
@@ -8,7 +8,7 @@ This page exists because of our commitment to security, compliance, and transpar
 
 !!! info "Version-Specific SBOM Details"
 
-    This SBOM reflects the components used in the most recent versions of all ecosystem components within Karafka. It is important to note that older versions may have different dependencies.
+    This SBOM reflects the components used in the most recent versions of all ecosystem components within Karafka. Older versions may have different dependencies.
 
 !!! tip "License Variability in OSS Dependencies"
 

--- a/Infrastructure/AWS-MSK-Guide.md
+++ b/Infrastructure/AWS-MSK-Guide.md
@@ -38,7 +38,7 @@ Standard brokers follow the traditional rolling update pattern described above. 
 
 !!! tip "Monitor MSK Express Despite No Maintenance Windows"
 
-    While MSK Express eliminates scheduled maintenance windows, proper instrumentation and monitoring remain essential. There have been rare but documented cases where MSK Express automatic updates caused librdkafka to enter non-recoverable states, requiring consumer or producer instance restarts. Always maintain robust monitoring and automated recovery mechanisms even with Express brokers.
+    While MSK Express eliminates scheduled maintenance windows, proper instrumentation and monitoring remain essential. There have been rare but documented cases where MSK Express automatic updates caused librdkafka to enter non-recoverable states, requiring consumer or producer instance restarts. Always maintain monitoring and automated recovery mechanisms even with Express brokers.
 
 !!! tip "Coordinator Failures During Rolling Upgrades"
 

--- a/Infrastructure/Active-Record-Connections-Management.md
+++ b/Infrastructure/Active-Record-Connections-Management.md
@@ -37,7 +37,7 @@ Active Record provides the `#verify!` method to handle dead connections dynamica
 
 ### Implementing Immediate Dead Connection Handling
 
-The process of managing dead database connections in Karafka is straightforward. You should subscribe to the `error.occurred` event. This event is triggered for many errors, including when an error indicating a dead connection is detected. To handle this, you can simply call 'ActiveRecord::Base.connection.verify! ', which checks the connection and re-establishes it if needed.
+The process of managing dead database connections in Karafka is straightforward. You should subscribe to the `error.occurred` event. This event is triggered for many errors, including when an error indicating a dead connection is detected. To handle this, you can call 'ActiveRecord::Base.connection.verify! ', which checks the connection and re-establishes it if needed.
 
 ```ruby
 Karafka::App.monitor.subscribe('error.occurred') do |event|
@@ -62,7 +62,7 @@ end
 
 ## Conclusion
 
-Karafka provides automatic database connection management for standard setups. However, when using database replicas, it's crucial to manage those connections to maintain system performance and stability manually. This process involves subscribing to Karafka's `worker.completed` event and explicitly releasing connections, ensuring they are available for subsequent use.
+Karafka provides automatic database connection management for standard setups. However, when using database replicas, manage those connections to maintain system performance and stability manually. This process involves subscribing to Karafka's `worker.completed` event and explicitly releasing connections, ensuring they are available for subsequent use.
 
 ## See Also
 

--- a/Infrastructure/Admin/Acls-API.md
+++ b/Infrastructure/Admin/Acls-API.md
@@ -1,6 +1,6 @@
 # Admin ACLs (Access Control Lists) API
 
-Apache Kafka ACLs (Access Control Lists) provide a robust mechanism to control permissions and access rights for Kafka resources. They are crucial for ensuring data security, managing consumer and producer interactions, and maintaining overall cluster integrity. Karafka extends these capabilities with a simplified, Ruby-friendly API.
+Apache Kafka ACLs (Access Control Lists) provide a mechanism to control permissions and access rights for Kafka resources. They are crucial for ensuring data security, managing consumer and producer interactions, and maintaining overall cluster integrity. Karafka extends these capabilities with a simplified, Ruby-friendly API.
 
 The Karafka Admin ACLs API provides a structured and easy-to-use interface for managing Kafka ACLs. It allows developers to create, delete, and describe ACLs with Ruby symbol-based definitions, enhancing readability and ease of use compared to the direct usage of `librdkafka` types.
 
@@ -20,7 +20,7 @@ ACLs ensure that only authorized entities can access Kafka's functionalities, wh
 
 The Karafka Admin ACLs API defines several "types" that categorize and specify details for ACL management in a Kafka environment. These types are crucial for setting up detailed and secure access controls.
 
-These types play a critical role in the Karafka Admin ACLs API, providing a structured and comprehensive way to manage access controls within a Kafka environment. Understanding and using these types enables you to secure and regulate operations in your Kafka clusters effectively.
+These types play a critical role in the Karafka Admin ACLs API, providing a structured way to manage access controls within a Kafka environment. Understanding and using these types enables you to secure and regulate operations in your Kafka clusters effectively.
 
 ### Resource Types
 
@@ -304,7 +304,7 @@ end
 
 ## Summary
 
-Karafka's Admin ACLs API provides a powerful yet user-friendly way to manage Kafka ACLs, ensuring secure and authorized access to Kafka resources. By using Ruby symbols and a structured API, it simplifies the process of ACL management, making it more accessible and less error-prone for Ruby developers.
+Karafka's Admin ACLs API provides a user-friendly way to manage Kafka ACLs, ensuring secure and authorized access to Kafka resources. By using Ruby symbols and a structured API, it simplifies the process of ACL management, making it more accessible and less error-prone for Ruby developers.
 
 Whether securing a small project or an enterprise-scale system, understanding and using Kafka ACLs through Karafka can significantly enhance your application's security and data governance.
 

--- a/Infrastructure/Admin/Configs-API.md
+++ b/Infrastructure/Admin/Configs-API.md
@@ -102,7 +102,7 @@ Operations types within this API are used to specify the configuration changes b
   </tbody>
 </table>
 
-These methods provide a robust interface for detailed management of configurations in a Kafka environment, offering both retrieval and update functionalities.
+These methods provide an interface for detailed management of configurations in a Kafka environment, offering both retrieval and update functionalities.
 
 ## Usage
 

--- a/Infrastructure/Declarative-Topics.md
+++ b/Infrastructure/Declarative-Topics.md
@@ -137,7 +137,7 @@ This will effectively ignore this topic from being altered in any way by Karafka
 
 !!! note "Config `active` Differs From `#active` Method"
 
-    Keep in mind that setting `active` to false inside the `#config` is **not** equivalent to disabling the topic consumption using the `active` method.
+    Setting `active` to false inside the `#config` is **not** equivalent to disabling the topic consumption using the `active` method.
 
 You can use Karafka to manage topics that you do not consume from as well by defining their config and making them inactive at the same time:
 
@@ -162,7 +162,7 @@ Setting such as above will allow Karafka to manage the topic while instructing K
 
 The topics management CLI **never** performs any destructive actions except the `delete` and `reset` commands. This means you can safely include the `karafka topics migrate` in your deployment pipelines if you wish to delegate topics management to Karafka.
 
-Please keep in mind that topics management API does **not** provide any means of concurrency locking when CLI commands are being executed.
+Topics management API does **not** provide any means of concurrency locking when CLI commands are being executed.
 
 ## Strict Declarative Topics Validation
 

--- a/Infrastructure/Forking.md
+++ b/Infrastructure/Forking.md
@@ -1,4 +1,4 @@
-Karafka under the hood relies on `librdkafka` to manage Kafka connections. It is crucial to understand that `librdkafka` is **not** fork-safe, which means special care must be taken when managing Ruby processes interacting with Kafka. This document provides guidelines for handling forking in Karafka, especially under macOS and in environments using Rails' Spring loader.
+Karafka under the hood relies on `librdkafka` to manage Kafka connections. `librdkafka` is **not** fork-safe, which means special care must be taken when managing Ruby processes interacting with Kafka. This document provides guidelines for handling forking in Karafka, especially under macOS and in environments using Rails' Spring loader.
 
 !!! tip "Ecosystem-Wide Recommendations"
 
@@ -38,7 +38,7 @@ These errors indicate processes in the middle of certain operations during a for
     - Establish a short-lived connection to a local development Kafka instance when Spring boots using `Karafka::Admin.cluster_info`
     - Disable Spring in development if you're encountering persistent issues
 
-Note that forking issues typically occur when the required dependencies aren't loaded in the parent process before forking. The underlying cause is related to how Objective-C DLLs handle forking on macOS.
+Forking issues typically occur when the required dependencies aren't loaded in the parent process before forking. The underlying cause is related to how Objective-C DLLs handle forking on macOS.
 
 ## Conclusion
 

--- a/Infrastructure/Multi-Cluster-Setup.md
+++ b/Infrastructure/Multi-Cluster-Setup.md
@@ -1,6 +1,6 @@
 # Multi-Cluster Setup
 
-Karafka is a robust framework that allows applications to interact with multiple Kafka clusters simultaneously. This provides enhanced scalability, redundancy, and flexibility, enabling developers to optimize data processing and manage message streams across various clusters with ease.
+Karafka is a framework that allows applications to interact with multiple Kafka clusters simultaneously. This provides enhanced scalability, redundancy, and flexibility, enabling developers to optimize data processing and manage message streams across various clusters with ease.
 
 ## Overview
 

--- a/Kafka/New-Rebalance-Protocol.md
+++ b/Kafka/New-Rebalance-Protocol.md
@@ -63,7 +63,7 @@ KIP-848 in librdkafka 2.12.0+ supports all major consumer features:
 - **Static group membership**: Using `group.instance.id` for stable member identities
 - **Rebalance callbacks**: Incremental assignment and revocation callbacks
 - **Manual and automatic offset management**: Both commit modes work as expected
-- **Rolling upgrades**: Seamless migration from classic protocol without downtime
+- **Rolling upgrades**: Migration from classic protocol without downtime
 
 Regex subscriptions are supported but behave differently from the classic protocol - see [Regex Subscription Changes](#regex-subscription-changes) for important details.
 

--- a/Pro/Cleaner-API.md
+++ b/Pro/Cleaner-API.md
@@ -170,7 +170,7 @@ Each fetched batch contained at most 500 messages.
   <img src="https://karafka.io/assets/misc/charts/cleaner_api/1kb_stdev.png" />
 </p>
 
-**Conclusion**: For messages approximating 1KB in size, the impact of employing the Cleaner API is virtually nonexistent. Its application doesn't notably affect the memory usage metrics for such small messages. However, it's worth noting that even if most messages are of this size, there could be occasional or periodic inflows of larger payloads. In such scenarios, the Cleaner API can help manage these sporadic spikes in memory usage. Therefore, even with predominantly 1KB messages, integrating the Cleaner API can be a prudent strategy if there's an anticipation of intermittently receiving messages with increased payloads.
+**Conclusion**: For messages approximating 1KB in size, the impact of employing the Cleaner API is virtually nonexistent. Its application doesn't notably affect the memory usage metrics for such small messages. However, even if most messages are of this size, there could be occasional or periodic inflows of larger payloads. In such scenarios, the Cleaner API can help manage these sporadic spikes in memory usage. Therefore, even with predominantly 1KB messages, integrating the Cleaner API can be a prudent strategy if there's an anticipation of intermittently receiving messages with increased payloads.
 
 ## Limitations
 

--- a/Pro/Consumer-Groups/Adaptive-Iterator.md
+++ b/Pro/Consumer-Groups/Adaptive-Iterator.md
@@ -120,7 +120,7 @@ Moreover, the Adaptive Iterator's frequent stopping and resetting cause the cons
 
 ## Summary
 
-While the Adaptive Iterator is an effective tool for managing sporadic long-processing messages, it introduces trade-offs in terms of performance and networking. The frequent stopping and seeking back can reduce processing efficiency, increase network traffic, and place a higher load on Kafka brokers. To minimize these impacts, it's crucial to carefully configure the safety margin and use the Adaptive Iterator in situations where processing times are relatively predictable, with only occasional spikes. For environments with consistently long processing times or high variability, consider using other features like Long-Running Jobs to maintain optimal performance and network usage.
+While the Adaptive Iterator is an effective tool for managing sporadic long-processing messages, it introduces trade-offs in terms of performance and networking. The frequent stopping and seeking back can reduce processing efficiency, increase network traffic, and place a higher load on Kafka brokers. To minimize these impacts, carefully configure the safety margin and use the Adaptive Iterator in situations where processing times are relatively predictable, with only occasional spikes. For environments with consistently long processing times or high variability, consider using other features like Long-Running Jobs to maintain optimal performance and network usage.
 
 ## See Also
 

--- a/Pro/Consumer-Groups/Enhanced-Active-Job.md
+++ b/Pro/Consumer-Groups/Enhanced-Active-Job.md
@@ -48,7 +48,7 @@ We recommend using the `:key` as then it can be used for combining Enhanced Acti
 
 ## Scheduled Jobs
 
-Karafka supports job scheduling via the [Scheduled Messages](Pro-Scheduled-Messages) feature, providing a robust framework for setting future execution times for tasks, akin to capabilities seen in other Rails Active Job adapters. This feature integrates seamlessly with Karafka's infrastructure, allowing users to schedule and manage tasks directly within the Kafka ecosystem.
+Karafka supports job scheduling via the [Scheduled Messages](Pro-Scheduled-Messages) feature, providing a framework for setting future execution times for tasks, akin to capabilities seen in other Rails Active Job adapters. This feature integrates with Karafka's infrastructure, allowing users to schedule and manage tasks directly within the Kafka ecosystem.
 
 To use the Scheduled Jobs functionality in Karafka, you must:
 
@@ -266,7 +266,7 @@ For non-VP setup, same error behaviors apply as for standard [Active Job adapter
 
 !!! note "Virtual Partitions Mark Jobs Only After All Finish"
 
-    Please keep in mind that if you use it in combination with [Virtual Partitions](Pro-Consumer-Groups-Virtual-Partitions), marking jobs as consumed (done) will happen only **after** all virtually partitioned consumers finished their work collectively. There is **no** intermediate marking in between jobs in that scenario.
+    If you use it in combination with [Virtual Partitions](Pro-Consumer-Groups-Virtual-Partitions), marking jobs as consumed (done) will happen only **after** all virtually partitioned consumers finished their work collectively. There is **no** intermediate marking in between jobs in that scenario.
 
 ## Behaviour on Revocation
 

--- a/Pro/Consumer-Groups/Expiring-Messages.md
+++ b/Pro/Consumer-Groups/Expiring-Messages.md
@@ -40,7 +40,7 @@ end
 
 Karafka's Expiring Messages feature ensures that failed messages are reprocessed after a short period. However, if the failed messages become too old, Karafka will skip them. This is because the Expiring Messages feature in Karafka automatically filters out messages that are older than the defined period. Therefore, if a failed message becomes older than the expiry period, it will not be included in the batch of messages that Karafka processes again. This is a design decision made to optimize resource utilization and prevent the processing of stale or irrelevant data.
 
-It is important to note that this behavior can be adjusted by changing the expiry period for messages in the configuration settings. It is also essential to ensure that the message expiry period is set to a value appropriate for the use case. For example, suppose the processing time for messages is expected to be longer than the expiry period. In that case, it may be necessary to increase the expiry period to ensure that failed messages are not skipped.
+This behavior can be adjusted by changing the expiry period for messages in the configuration settings. Also ensure that the message expiry period is set to a value appropriate for the use case. For example, suppose the processing time for messages is expected to be longer than the expiry period. In that case, it may be necessary to increase the expiry period to ensure that failed messages are not skipped.
 
 ## Limitations
 

--- a/Pro/Consumer-Groups/Parallel-Segments.md
+++ b/Pro/Consumer-Groups/Parallel-Segments.md
@@ -258,7 +258,7 @@ end
 
 ### Testing and Validating Distribution
 
-It's crucial to test your partitioning strategy because the combination of your partitioner and the reducer may not distribute data evenly.
+Test your partitioning strategy because the combination of your partitioner and the reducer may not distribute data evenly.
 
 #### Understanding the Default Reducer
 
@@ -517,7 +517,7 @@ This will:
 
 - Create consumer groups: `analytics-parallel-0`, `analytics-parallel-1`, `analytics-parallel-2`, `analytics-parallel-3`
 - Set their offsets to match the original `analytics` consumer group
-- Allow seamless continuation of processing from where the original group left off
+- Allow continuation of processing from where the original group left off
 
 ### Collapse Command
 
@@ -670,7 +670,7 @@ end
 
 ### Parallel Segments with Dead Letter Queue
 
-Parallel Segments work seamlessly with Dead Letter Queue:
+Parallel Segments work with Dead Letter Queue:
 
 ```ruby
 consumer_group :resilient_processing do
@@ -694,7 +694,7 @@ end
 
 Parallel Segments provide a way to scale CPU-intensive message processing in Karafka. By distributing work across multiple consumer groups, you can achieve horizontal scaling for computationally heavy workloads while maintaining message ordering guarantees within each segment.
 
-While the trade-off in network bandwidth usage is important to consider, the performance gains for certain workloads often justify this cost. Combined with Karafka's other features like Virtual Partitions, Dead Letter Queue, and monitoring, Parallel Segments offer a robust solution for high-throughput, CPU-intensive message processing scenarios.
+While the trade-off in network bandwidth usage is important to consider, the performance gains for certain workloads often justify this cost. Combined with Karafka's other features like Virtual Partitions, Dead Letter Queue, and monitoring, Parallel Segments offer a solution for high-throughput, CPU-intensive message processing scenarios.
 
 Remember to use the CLI commands for smooth migrations and ongoing management of your parallel segments deployment. The safety mechanisms built into these commands help prevent common pitfalls and ensure reliable operation of your parallel processing infrastructure.
 

--- a/Pro/Consumer-Groups/Piping.md
+++ b/Pro/Consumer-Groups/Piping.md
@@ -1,4 +1,4 @@
-In complex systems where applications act as part of a larger data-processing ecosystem, efficiently passing data between processes is crucial. Karafka Pro includes a robust feature for message piping, allowing applications to forward processing results seamlessly to subsequent stages or other applications. This document explores the concept, use cases, and benefits of using message piping in Karafka Pro.
+In complex systems where applications act as part of a larger data-processing ecosystem, efficiently passing data between processes is crucial. Karafka Pro includes a feature for message piping, allowing applications to forward processing results to subsequent stages or other applications. This document explores the concept, use cases, and benefits of using message piping in Karafka Pro.
 
 ## What is Message Piping?
 
@@ -104,7 +104,7 @@ Transactional piping ensures that message forwarding completes successfully or n
 
 ## Conclusion
 
-Karafka Pro's message piping feature significantly enhances the flexibility and efficiency of Kafka-based systems. Facilitating smooth data transfer between components without tight coupling enables the creation of scalable, maintainable, and robust distributed systems. Note, however, that this feature is part of Karafka Pro and requires a commercial license.
+Karafka Pro's message piping feature significantly enhances the flexibility and efficiency of Kafka-based systems. Facilitating smooth data transfer between components without tight coupling enables the creation of scalable, maintainable, and robust distributed systems. This feature is part of Karafka Pro and requires a commercial license.
 
 ## See Also
 

--- a/Pro/FIPS-Support.md
+++ b/Pro/FIPS-Support.md
@@ -68,7 +68,7 @@ Karafka includes a fingerprinting feature that provides tamper resistance for me
 
 All dependencies have been reviewed for FIPS compatibility regarding cryptographic hashing algorithms to ensure they don't use non-approved methods like MD5. For a complete listing of all dependencies and their security status, please refer to our [Software Bill of Materials (SBOM) document](Development-SBOM).
 
-For more comprehensive information about Karafka's security posture, including our approach to dependency management, vulnerability handling, and secure coding practices, please consult our [Security Guidelines documentation](Pro-Security).
+For more information about Karafka's security posture, including our approach to dependency management, vulnerability handling, and secure coding practices, please consult our [Security Guidelines documentation](Pro-Security).
 
 ## librdkafka FIPS Support
 
@@ -97,7 +97,7 @@ When operating in FIPS mode, the following limitations apply:
 
 ## Summary
 
-Karafka Pro and Enterprise editions provide comprehensive support for FIPS 140-2 requirements through their implementation of validated cryptographic modules, secure communication channels, and robust at-rest encryption.
+Karafka Pro and Enterprise editions provide comprehensive support for FIPS 140-2 requirements through their implementation of validated cryptographic modules, secure communication channels, and at-rest encryption.
 
 While we strive to maintain FIPS compatibility, we encourage users to contact us with any issues or suggestions for improvement to help us continue enhancing Karafka's security features.
 

--- a/Pro/Features-Compatibility.md
+++ b/Pro/Features-Compatibility.md
@@ -33,7 +33,7 @@ class KarafkaApp < Karafka::App
 end
 ```
 
-Please keep in mind that with Virtual Partitions, the offset will be committed after all the Virtual Partitions work is done. There is **no** "per job" marking as processed.
+With Virtual Partitions, the offset will be committed after all the Virtual Partitions work is done. There is **no** "per job" marking as processed.
 
 ## Enhanced Dead Letter Queue + Virtual Partitions
 
@@ -87,13 +87,13 @@ In Karafka's Virtual Partitions, the offset_metadata_strategy setting, configura
 
 ## Routing Patterns + Dead Letter Queue
 
-While Karafka's Routing Patterns feature integrates seamlessly with the Dead Letter Queue (DLQ) mechanism, developers are advised to exercise caution. Specifically, there's a potential issue where an imprecisely crafted regular expression could inadvertently match both primary and DLQ topics. This misconfiguration might result in messages from the DLQ being consumed in an unexpected loop, especially if the DLQ topic isn't explicitly targeted for consumption.
+While Karafka's Routing Patterns feature integrates with the Dead Letter Queue (DLQ) mechanism, developers are advised to exercise caution. Specifically, there's a potential issue where an imprecisely crafted regular expression could inadvertently match both primary and DLQ topics. This misconfiguration might result in messages from the DLQ being consumed in an unexpected loop, especially if the DLQ topic isn't explicitly targeted for consumption.
 
 You can read more about this issue [here](Pro-Routing-Patterns#dlq-accidental-auto-consumption).
 
 ## Messages At Rest Encryption + Custom Headers Deserializer and Encryption
 
-When using Karafka's encryption features, it's important to note that encryption may not work as expected if you use a custom headers deserializer. Custom deserialization of headers can alter how encryption headers are processed, potentially leading to issues in correctly encrypting or decrypting messages. In cases where custom headers deserialization is necessary, it is recommended to consult with Karafka Pro support for guidance to ensure that encryption functionalities are properly integrated and maintained within your application.
+When using Karafka's encryption features, encryption may not work as expected if you use a custom headers deserializer. Custom deserialization of headers can alter how encryption headers are processed, potentially leading to issues in correctly encrypting or decrypting messages. In cases where custom headers deserialization is necessary, it is recommended to consult with Karafka Pro support for guidance to ensure that encryption functionalities are properly integrated and maintained within your application.
 
 ## Adaptive Iterator + Long-Running Jobs
 

--- a/Pro/Features-List.md
+++ b/Pro/Features-List.md
@@ -42,7 +42,7 @@ Below you can find the list of the Pro features with their brief description:
 
 - [Multiplexing](Pro-Consumer-Groups-Multiplexing) - This feature allows a single process to establish multiple independent connections to the same Kafka topic, enhancing parallel processing and throughput. This capability enables more efficient data handling and improved performance in consuming messages.
 
-- [Piping](Pro-Consumer-Groups-Piping) - Feature allowing applications to forward processing results seamlessly to subsequent stages or other applications.
+- [Piping](Pro-Consumer-Groups-Piping) - Feature allowing applications to forward processing results to subsequent stages or other applications.
 
 - [Recurring Tasks](Pro-Recurring-Tasks) - Supports defining tasks that run at specific times on a regular basis, similar to cron jobs. It is ideal for automating periodic operations directly within Karafka, ensuring consistent and reliable execution.
 

--- a/Pro/Messages-At-Rest-Encryption.md
+++ b/Pro/Messages-At-Rest-Encryption.md
@@ -4,7 +4,7 @@ Karafka uses RSA asymmetric encryption, so your producers do not have to have th
 
 !!! warning "Custom Headers Deserializer and Encryption"
 
-    When using Karafka's encryption features, it's important to note that encryption may not work as expected if you use a custom headers deserializer. Custom deserialization of headers can alter how encryption headers are processed, potentially leading to issues in correctly encrypting or decrypting messages. In cases where custom headers deserialization is necessary, it is recommended to consult with Karafka Pro support for guidance to ensure that encryption functionalities are properly integrated and maintained within your application.
+    When using Karafka's encryption features, encryption may not work as expected if you use a custom headers deserializer. Custom deserialization of headers can alter how encryption headers are processed, potentially leading to issues in correctly encrypting or decrypting messages. In cases where custom headers deserialization is necessary, it is recommended to consult with Karafka Pro support for guidance to ensure that encryption functionalities are properly integrated and maintained within your application.
 
 ## Enabling Encryption
 

--- a/Pro/Web-UI.md
+++ b/Pro/Web-UI.md
@@ -62,7 +62,7 @@ This dashboard views show Karafka consumers' groups' health states with their la
 
 ## Topics Insights
 
-The "Topics Insights" feature in Karafka Pro Web UI is a comprehensive suite designed to provide users with detailed information and analytics about their Kafka topics. This feature is crucial for developers who must ensure optimal configuration and performance of their Kafka topics. You can learn more about this feature [here](Pro-Web-UI-Topics-Insights).
+The "Topics Insights" feature in Karafka Pro Web UI is a suite designed to provide users with detailed information and analytics about their Kafka topics. This feature is crucial for developers who must ensure optimal configuration and performance of their Kafka topics. You can learn more about this feature [here](Pro-Web-UI-Topics-Insights).
 
 ## Explorer
 
@@ -137,7 +137,7 @@ This feature has its own dedicated documentation that you can access [here](Pro-
 
 ## Policies
 
-Karafka's Web UI includes a comprehensive policies engine that provides granular control over user actions across all UI components. This engine allows administrators to define and enforce policies on what specific users can view and do within the Web UI, ensuring compliance with data protection and privacy standards.
+Karafka's Web UI includes a policies engine that provides granular control over user actions across all UI components. This engine allows administrators to define and enforce policies on what specific users can view and do within the Web UI, ensuring compliance with data protection and privacy standards.
 
 This feature has its own dedicated documentation that you can access [here](Pro-Web-UI-Policies).
 
@@ -200,7 +200,7 @@ body.controller-errors {
 - Custom assets are properly cached by the browser for optimal performance
 - Custom styling is applied to all pages, including error pages
 
-When used in combination with the Branding feature, custom styling provides a comprehensive way to tailor the Karafka Web UI to your organization's needs.
+When used in combination with the Branding feature, custom styling provides a way to tailor the Karafka Web UI to your organization's needs.
 
 ## Topics Management
 

--- a/Pro/Web-UI/Commanding.md
+++ b/Pro/Web-UI/Commanding.md
@@ -118,7 +118,7 @@ Quieting is a command designed to gracefully reduce the activity of a consumer p
 The stopping command is used to halt a consumer process entirely. This command should be used with caution as it stops all processing activities after `shutdown_timeout` is reached. Stopping is typically employed when a consumer needs to be taken offline for upgrades, troubleshooting, or when decommissioning is required. Once stopped, a consumer process will need to be manually restarted, and it will resume from the last committed offset in Kafka, ensuring no loss of data but requiring careful management to avoid processing delays or other operational impacts.
 
 !!! warning "Topics and Partitions Reassignment"
-    When a consumer is stopped, its assignments are redistributed among the remaining active consumers in the group, ensuring that message processing continues seamlessly without interruption.
+    When a consumer is stopped, its assignments are redistributed among the remaining active consumers in the group, ensuring that message processing continues without interruption.
 
 #### Use Cases
 
@@ -295,7 +295,7 @@ The commanding feature in Karafka Pro uses the Pro Iterator to establish a pub-s
 
 Unlike standard data flows, this special connection is built to avoid saturation and flow any potential instabilities, where messages pass from listeners through queues to consumers. Standard flows could be overwhelmed during critical moments, significantly reducing responsiveness when needed most. By bypassing the typical data flow path, the commanding feature maintains a high level of responsiveness, even under heavy system load.
 
-This dedicated subscription, while not "mission-critical", is designed to be reliable, incorporating recovery procedures and automatic reconnections. It does not publish statistics or other metrics, focusing on efficient management and swift responses to administrative commands. This approach, in turn, ensures robust and continuous operation, maintaining system stability and operational efficiency.
+This dedicated subscription, while not "mission-critical", is designed to be reliable, incorporating recovery procedures and automatic reconnections. It does not publish statistics or other metrics, focusing on efficient management and swift responses to administrative commands. This approach, in turn, ensures continuous operation, maintaining system stability and operational efficiency.
 
 ### Network Traffic Characteristics
 
@@ -317,7 +317,7 @@ Key points include:
 
 Karafka Pro's consumer control capabilities are essential for any organization looking to use Kafka for real-time data processing and streaming. They provide the necessary controls to manage consumer behavior effectively at both process and partition levels, ensuring that Kafka clusters are performant and resilient under various operating conditions.
 
-The combination of process-level commands (trace, quiet, stop) and partition-level controls (pause, resume, offset adjustment) provides a comprehensive toolkit for administrators to implement precise control strategies and resolve issues with minimal disruption to the overall message processing workflow.
+The combination of process-level commands (trace, quiet, stop) and partition-level controls (pause, resume, offset adjustment) provides a toolkit for administrators to implement precise control strategies and resolve issues with minimal disruption to the overall message processing workflow.
 
 ## See Also
 

--- a/Pro/Web-UI/Topics-Insights.md
+++ b/Pro/Web-UI/Topics-Insights.md
@@ -1,4 +1,4 @@
-The "Topics Insights" feature in Karafka Pro Web UI is a comprehensive suite designed to provide users with detailed information and analytics about their Kafka topics. This feature is crucial for developers who must ensure optimal configuration and performance of their Kafka topics.
+The "Topics Insights" feature in Karafka Pro Web UI is a suite designed to provide users with detailed information and analytics about their Kafka topics. This feature is crucial for developers who must ensure optimal configuration and performance of their Kafka topics.
 
 ## Configuration Explorer
 
@@ -79,7 +79,7 @@ Understanding offsets is useful in several scenarios:
 
 ## Summary
 
-In summary, the Distribution Insights feature of the Karafka Pro Web UI is a powerful tool that empowers users with the necessary insights to manage, optimize, and troubleshoot Kafka topics effectively. By providing detailed configurations, replication status, and distribution analytics, it enables administrators to maintain a robust and efficient Kafka environment, thereby enhancing performance, scalability, and troubleshooting capabilities.
+In summary, the Distribution Insights feature of the Karafka Pro Web UI is a tool that empowers users with the necessary insights to manage, optimize, and troubleshoot Kafka topics effectively. By providing detailed configurations, replication status, and distribution analytics, it enables administrators to maintain an efficient Kafka environment, thereby enhancing performance, scalability, and troubleshooting capabilities.
 
 ## See Also
 

--- a/Pro/Web-UI/Topics-Management.md
+++ b/Pro/Web-UI/Topics-Management.md
@@ -199,7 +199,7 @@ When managing topics through the Karafka Web UI Pro, consider these best practic
 
 ## Summary
 
-The topic management features in Karafka Web UI Pro provide a comprehensive solution for administering your Kafka topics without leaving the web interface. With intuitive interfaces for creating topics, modifying configurations, and managing partitions, these tools streamline common administrative tasks and provide a user-friendly alternative to command-line tools.
+The topic management features in Karafka Web UI Pro provide a solution for administering your Kafka topics without leaving the web interface. With intuitive interfaces for creating topics, modifying configurations, and managing partitions, these tools streamline common administrative tasks and provide a user-friendly alternative to command-line tools.
 
 Combined with other Karafka Pro features like [Data Explorer](Pro-Web-UI-Explorer), [Topics Insights](Pro-Web-UI-Topics-Insights), and [Search](Pro-Web-UI-Search), topic management completes the toolset needed for efficient Kafka operations and maintenance.
 

--- a/Upgrades/Karafka/2.2.md
+++ b/Upgrades/Karafka/2.2.md
@@ -8,9 +8,9 @@ As always, please make sure you have upgraded to the most recent version of `2.1
 
 If you are not using Kafka ACLs, there is no action you need to take.
 
-If you are using Kafka ACLs and you've set up permissions for `karafka_admin` group, please note that this name has now been changed and is subject to Consumer Name Mapping.
+If you are using Kafka ACLs and you've set up permissions for `karafka_admin` group, this name has now been changed and is subject to Consumer Name Mapping.
 
-That means you must ensure that the new consumer group that by default equals `CLIENT_ID_karafka_admin` has appropriate permissions. Please note that the Web UI also uses this group.
+That means you must ensure that the new consumer group that by default equals `CLIENT_ID_karafka_admin` has appropriate permissions. The Web UI also uses this group.
 
 `Karafka::Admin` now has its own set of configuration options available, and you can find more details about that [here](Infrastructure-Admin-API#configuration).
 

--- a/Upgrades/Upgrading.md
+++ b/Upgrades/Upgrading.md
@@ -1,4 +1,4 @@
-This documentation page provides recommended strategies for upgrading Karafka and its dependencies to ensure a smooth and seamless upgrade process. Upgrading Karafka and its dependencies is essential to benefit from the latest features, bug fixes, and security enhancements. It is necessary to follow these strategies to minimize disruptions and avoid compatibility issues during the upgrade.
+This documentation page provides recommended strategies for upgrading Karafka and its dependencies to ensure a smooth upgrade process. Upgrading Karafka and its dependencies is essential to benefit from the latest features, bug fixes, and security enhancements. It is necessary to follow these strategies to minimize disruptions and avoid compatibility issues during the upgrade.
 
 !!! tip "Pro & Enterprise Upgrade Support"
 
@@ -46,7 +46,7 @@ The practical recommendation is: **apply patch releases as soon as they are avai
 
     If you attempt to deploy the updated Web UI before the Karafka consumer processes, you may encounter errors. This could range from 500 Internal Server errors to incorrect or missing offset-related data displays.
 
-    It's critical to ensure the order of operations - Karafka consumers processes first, then the Web UI. This will provide a smoother transition to the new version of the Web UI.
+    Ensure the order of operations - Karafka consumers processes first, then the Web UI. This will provide a smoother transition to the new version of the Web UI.
 
 1. **Monitor**: During and after the upgrade, closely monitor the application's performance, logs, and error reports.
 

--- a/WaterDrop/Custom-Partitioners.md
+++ b/WaterDrop/Custom-Partitioners.md
@@ -10,7 +10,7 @@ In Apache Kafka, a partitioner determines how records are placed among the parti
 
 1. **Performance Optimization**: In some instances, optimizing partitioning logic based on consumption patterns can lead to more efficient data processing.
 
-1. **Compatibility and Integration**: When integrating with other systems, you might need to align your partitioning strategy with the external systems for seamless data flow and processing.
+1. **Compatibility and Integration**: When integrating with other systems, you might need to align your partitioning strategy with the external systems for data flow and processing.
 
 ## Building a Custom Partitioner
 

--- a/WaterDrop/Monitoring-and-Logging.md
+++ b/WaterDrop/Monitoring-and-Logging.md
@@ -112,7 +112,7 @@ Karafka [Web UI](Web-UI-Getting-Started) is a user interface for the Karafka fra
 
 WaterDrop comes equipped with a `LoggerListener`, a useful feature designed to facilitate the reporting of WaterDrop's operational details directly into the assigned logger. The `LoggerListener` provides a convenient way of tracking the events and operations that occur during the usage of WaterDrop, enhancing transparency and making debugging and issue tracking easier.
 
-However, it's important to note that this Logger Listener is not subscribed by default. This means that WaterDrop does not automatically send operation data to your logger out of the box. This design choice has been made to give users greater flexibility and control over their logging configuration.
+However, this Logger Listener is not subscribed by default. This means that WaterDrop does not automatically send operation data to your logger out of the box. This design choice has been made to give users greater flexibility and control over their logging configuration.
 
 To use this functionality, you need to manually subscribe the `LoggerListener` to WaterDrop instrumentation. Below, you will find an example demonstrating how to perform this subscription.
 

--- a/WaterDrop/Testing.md
+++ b/WaterDrop/Testing.md
@@ -4,7 +4,7 @@
 
     If you're using WaterDrop with Karafka, consider the `karafka-testing` gem for RSpec integration. Detailed documentation on its usage can be found [here](Basics-Testing).
 
-Testing is a crucial component of any software development cycle. Ensuring that message production behaves as expected is essential when working with Kafka. Thankfully, WaterDrop provides a robust testing mechanism for its producers.
+Testing is a crucial component of any software development cycle. Ensuring that message production behaves as expected is essential when working with Kafka. Thankfully, WaterDrop provides a testing mechanism for its producers.
 
 When testing code that uses WaterDrop producers, you have two primary strategies:
 

--- a/WaterDrop/Variants.md
+++ b/WaterDrop/Variants.md
@@ -141,11 +141,11 @@ high_importance.produce_async(topic: 'critical_events', payload: event.to_json)
 
 When using variants in WaterDrop, there are specific edge cases and operational nuances that you should be aware of to ensure optimal performance and behavior:
 
-- **Buffering Behavior Across Variants**: It is crucial to understand that while `topic_config` specific settings are preserved per message, the `max_wait_timeout` applied during the flush operation will correspond to the variant that starts the flushing. This means that messages from other variants that were buffered may be dispatched using the `max_wait_timeout` of the variant currently flushing the data. Since variants share a single producer buffer, this can affect how messages are processed.
+- **Buffering Behavior Across Variants**: While `topic_config` specific settings are preserved per message, the `max_wait_timeout` applied during the flush operation will correspond to the variant that starts the flushing. This means that messages from other variants that were buffered may be dispatched using the `max_wait_timeout` of the variant currently flushing the data. Since variants share a single producer buffer, this can affect how messages are processed.
 
 - **Inconclusive Error Messages**: Redefining `max_wait_timeout` without aligning it with other librdkafka settings can lead to inconclusive error. This issue arises because the timeout settings may not synchronize well with other operational parameters, potentially leading to errors that are difficult to diagnose. For a deeper understanding of this issue and how it might affect your Kafka operations, refer to the [Error Handling](WaterDrop-Error-Handling) documentation.
 
-- **Immutable acks for Idempotent and Transactional Producers**: When working with idempotent or transactional producers, it is important to note that the `acks` setting is immutable and automatically set to `all`. This configuration cannot be altered through variants, as ensuring exactly-once semantics requires a fixed acknowledgment policy. Attempting to change the acks setting for these producers will result in an error.
+- **Immutable acks for Idempotent and Transactional Producers**: When working with idempotent or transactional producers, the `acks` setting is immutable and automatically set to `all`. This configuration cannot be altered through variants, as ensuring exactly-once semantics requires a fixed acknowledgment policy. Attempting to change the acks setting for these producers will result in an error.
 
 These details are critical in effectively managing and troubleshooting your Kafka message production environment, especially when using the flexibility of variants for different topic configurations.
 

--- a/Web-UI/Components.md
+++ b/Web-UI/Components.md
@@ -12,7 +12,7 @@ Karafka Web UI is an intuitive tool that visually represents the metrics related
 
 ## Active Consumption vs. Storage Topics
 
-It's important to understand how Karafka Web UI interacts with different topics:
+Understand how Karafka Web UI interacts with different topics:
 
 - **Reports Topic (Active Consumption)**: Karafka Web UI actively consumes only the `karafka_consumers_reports` topic. You will see this consumer group subscription in your logs. This is the primary data source for tracking and processing consumer states.
 
@@ -28,4 +28,4 @@ Below you can find the diagram of the whole data flow:
 
 !!! note "Diagram Is an Abstract Flow"
 
-    Please note, that this is an **abstract** flow visualisation. Karafka Web works well even when there is one `karafka server` process running.
+    This is an **abstract** flow visualisation. Karafka Web works well even when there is one `karafka server` process running.

--- a/Web-UI/Data-Management.md
+++ b/Web-UI/Data-Management.md
@@ -49,7 +49,7 @@ However, this delay is generally irrelevant when analyzing patterns and conducti
 
 ## Conclusion
 
-Karafka Web UI offers a robust, efficient, and reliable solution for monitoring Karafka-based environments. Its direct use of Kafka for data storage and sophisticated schema management and migration capabilities positions it as a powerful tool for users seeking to use Kafka in their applications.
+Karafka Web UI offers an efficient and reliable solution for monitoring Karafka-based environments. Its direct use of Kafka for data storage and sophisticated schema management and migration capabilities positions it as a powerful tool for users seeking to use Kafka in their applications.
 
 ## See Also
 

--- a/Web-UI/Development-vs-Production.md
+++ b/Web-UI/Development-vs-Production.md
@@ -1,6 +1,6 @@
 # Web UI Setup for Development vs Production
 
-Karafka Web UI can operate in production mode. It is, however, essential to understand how it works and its limitations.
+Karafka Web UI can operate in production mode. However, understand how it works and its limitations.
 
 ## Dedicated Web UI Processes
 
@@ -107,7 +107,7 @@ bundle exec karafka-web install --replication-factor 5
 
 This section **only** applies to the Multi-Tenant add-on mode.
 
-Please keep in mind that in order for Karafka Web UI to work with Heroku Kafka Multi-Tenant Addon, **all** Karafka Web UI, topics need to be prefixed with your `KAFKA_PREFIX`:
+In order for Karafka Web UI to work with Heroku Kafka Multi-Tenant Addon, **all** Karafka Web UI, topics need to be prefixed with your `KAFKA_PREFIX`:
 
 ### Topics Automatic Prefix
 
@@ -150,7 +150,7 @@ Please take note of the following potential issue:
 
 If you attempt to deploy the updated Web UI before the Karafka consumer processes, you may encounter errors. This could range from 500 Internal Server errors to incorrect or missing offset-related data displays.
 
-It's critical to ensure the order of operations - Karafka consumers processes first, then the Web UI. This will provide a smoother transition to the new version of the Web UI.
+Ensure the order of operations - Karafka consumers processes first, then the Web UI. This will provide a smoother transition to the new version of the Web UI.
 
 ## See Also
 

--- a/Web-UI/Features.md
+++ b/Web-UI/Features.md
@@ -2,7 +2,7 @@
 
 Karafka Web UI contains several features allowing you to understand your system's karafka consumption process.
 
-Below you can find a comprehensive description of the most important features you can use.
+Below you can find a description of the most important features you can use.
 
 !!! info "Web UI Enhancements in Karafka Pro"
 
@@ -142,7 +142,7 @@ The Routing UI view allows users to inspect Karafka's routing configuration, inc
 
     The Data Explorer is part of [Karafka Pro](https://karafka.io/#become-pro).
 
-Karafka Data Explorer is an essential tool for users seeking to navigate and comprehend the data produced to Kafka. Offering an intuitive interface and a deep understanding of the routing table, the explorer ensures that users can access deserialized data effortlessly for seamless viewing. You can read more about it [here](Pro-Web-UI#explorer).
+Karafka Data Explorer is an essential tool for users seeking to navigate and comprehend the data produced to Kafka. Offering an intuitive interface and a deep understanding of the routing table, the explorer ensures that users can access deserialized data effortlessly for viewing. You can read more about it [here](Pro-Web-UI#explorer).
 
 <p align="center">
   <img src="https://karafka.io/assets/misc/printscreens/web-ui/explorer3.png" alt="karafka web explorer view" />
@@ -247,5 +247,5 @@ Each check may display one of the following statuses:
 
 - [Web UI Getting Started](Web-UI-Getting-Started) - Quick start guide for setting up Karafka Web UI
 - [Pro Web UI](Pro-Web-UI) - Advanced Pro features for Web UI
-- [Monitoring and Logging](Infrastructure-Monitoring-and-Logging) - Comprehensive monitoring and logging strategies
+- [Monitoring and Logging](Infrastructure-Monitoring-and-Logging) - Monitoring and logging strategies
 - [Web UI About](Web-UI-About) - Introduction and overview of Karafka Web UI


### PR DESCRIPTION
Fourth and final readability pass, covering the remaining pages that had two or more offenders after PRs #793, #794, and #795. Applies the rules documented in Development/Technical-Writing.md (lines 72-74): cut throat-clearing openers, delete minimizing filler, remove empty marketing words where they carry no information.

78 changes across 43 files spanning Basics, Consumer-Groups, WaterDrop, Infrastructure, Pro Consumer-Groups, Pro features, Pro Web-UI, Web-UI, Upgrades, and Kafka/Development. Judgment-based, not mechanical: kept load-bearing words (substantiated 'powerful tool', 'robustness' nouns, exhaustive 'comprehensive', genuine 'simple'/'essential' adjectives, 'essentially'=in-effect), preserved the conversational voice, and deliberately left the Pro Enterprise sales pages and 'while ...' subordinate clauses untouched where an imperative would not read naturally. Code, links, headings, and admonition titles untouched.

Verified: npm run lint clean, ./bin/mklint strict build passes, every link/anchor target and inline-code span byte-identical, all bold emphasis balanced.