### PR TITLE
refactor: token-based code detection for the STE lint rules

### DIFF
--- a/.rules/code-lines.js
+++ b/.rules/code-lines.js
@@ -1,0 +1,26 @@
+// Shared helper for the Karafka STE lint rules.
+//
+// Returns a Set of 1-indexed line numbers that fall inside fenced or indented
+// code blocks, derived from the markdown-it token stream (rules declare
+// `parser: 'markdownit'`). This replaces naive fence toggling
+// (`/^(`{3,}|~{3,})/` flipping a boolean), which has two bugs:
+//   - mixed fences: a ``` line inside a ~~~ block wrongly flips the state;
+//   - indented code: 4-space code blocks have no fence and are missed entirely.
+// Token `map` is [startLine, endLine) 0-indexed; both fence and code_block
+// tokens cover the whole block including the fence lines.
+module.exports = function codeLines(params) {
+  const set = new Set();
+  const md = params && params.parsers && params.parsers.markdownit;
+  const tokens = (md && md.tokens) || [];
+  for (const token of tokens) {
+    if (
+      (token.type === 'fence' || token.type === 'code_block') &&
+      Array.isArray(token.map)
+    ) {
+      for (let ln = token.map[0] + 1; ln <= token.map[1]; ln++) {
+        set.add(ln);
+      }
+    }
+  }
+  return set;
+};

--- a/.rules/max-sentence-length.js
+++ b/.rules/max-sentence-length.js
@@ -32,16 +32,12 @@ module.exports = {
     const maximum = config.maximum || 25;
     const maximumStep = config.maximum_step || 20;
     const lines = params.lines;
-    let inCodeBlock = false;
+    const codeLines = require('./code-lines')(params);
 
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i].trim();
 
-      if (/^(`{3,}|~{3,})/.test(trimmed)) {
-        inCodeBlock = !inCodeBlock;
-        continue;
-      }
-      if (inCodeBlock || trimmed === '') {
+      if (codeLines.has(i + 1) || trimmed === '') {
         continue;
       }
       // Skip non-prose lines: headers, table rows, HTML lines, admonition markers.

--- a/.rules/no-contractions.js
+++ b/.rules/no-contractions.js
@@ -6,6 +6,7 @@
 // rules leave untouched - so verbatim code and quoted examples keep their text.
 
 const terms = require('./ste-terms.json');
+const findCodeLines = require('./code-lines');
 
 function maskProtected(line) {
   const blank = (match) => ' '.repeat(match.length);
@@ -33,17 +34,13 @@ module.exports = {
   parser: 'markdownit',
   function: function rule(params, onError) {
     const lines = params.lines;
-    let inCodeBlock = false;
+    const codeLines = findCodeLines(params);
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const trimmed = line.trim();
 
-      if (/^(`{3,}|~{3,})/.test(trimmed)) {
-        inCodeBlock = !inCodeBlock;
-        continue;
-      }
-      if (inCodeBlock) {
+      if (codeLines.has(i + 1)) {
         continue;
       }
       if (/^#{1,6}\s/.test(trimmed)) {

--- a/.rules/no-generic-admonition-title.js
+++ b/.rules/no-generic-admonition-title.js
@@ -25,17 +25,13 @@ module.exports = {
   parser: 'markdownit',
   function: function rule(params, onError) {
     const lines = params.lines;
-    let inCodeBlock = false;
+    const codeLines = require('./code-lines')(params);
     const admonition = /^(?:!!!|\?\?\?\+?)\s+(\w+)\s+"([^"]*)"\s*$/;
 
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i].trim();
 
-      if (/^(`{3,}|~{3,})/.test(trimmed)) {
-        inCodeBlock = !inCodeBlock;
-        continue;
-      }
-      if (inCodeBlock) {
+      if (codeLines.has(i + 1)) {
         continue;
       }
 

--- a/.rules/no-horizontal-rule.js
+++ b/.rules/no-horizontal-rule.js
@@ -5,16 +5,12 @@ module.exports = {
   parser: 'markdownit',
   function: function rule(params, onError) {
     const lines = params.lines;
-    let inCodeBlock = false;
+    const codeLines = require('./code-lines')(params);
 
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i].trim();
 
-      if (/^(`{3,}|~{3,})/.test(trimmed)) {
-        inCodeBlock = !inCodeBlock;
-      }
-
-      if (!inCodeBlock && /^---\s*$/.test(trimmed)) {
+      if (!codeLines.has(i + 1) && /^---\s*$/.test(trimmed)) {
         onError({
           lineNumber: i + 1,
           detail: 'Horizontal rule found. Remove the --- separator line.',

--- a/.rules/no-markdown-tables.js
+++ b/.rules/no-markdown-tables.js
@@ -8,16 +8,12 @@ module.exports = {
   parser: 'markdownit',
   function: function rule(params, onError) {
     const lines = params.lines;
-    let inCodeBlock = false;
+    const codeLines = require('./code-lines')(params);
 
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i].trim();
 
-      if (/^(`{3,}|~{3,})/.test(trimmed)) {
-        inCodeBlock = !inCodeBlock;
-        continue;
-      }
-      if (inCodeBlock) {
+      if (codeLines.has(i + 1)) {
         continue;
       }
 

--- a/.rules/no-md-link-extension.js
+++ b/.rules/no-md-link-extension.js
@@ -14,18 +14,14 @@ module.exports = {
       return;
     }
     const lines = params.lines;
-    let inCodeBlock = false;
+    const codeLines = require('./code-lines')(params);
     const linkTarget = /\]\(([^)]+)\)/g;
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const trimmed = line.trim();
 
-      if (/^(`{3,}|~{3,})/.test(trimmed)) {
-        inCodeBlock = !inCodeBlock;
-        continue;
-      }
-      if (inCodeBlock) {
+      if (codeLines.has(i + 1)) {
         continue;
       }
 

--- a/.rules/no-please.js
+++ b/.rules/no-please.js
@@ -22,17 +22,13 @@ module.exports = {
   parser: 'markdownit',
   function: function rule(params, onError) {
     const lines = params.lines;
-    let inCodeBlock = false;
+    const codeLines = require('./code-lines')(params);
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const trimmed = line.trim();
 
-      if (/^(`{3,}|~{3,})/.test(trimmed)) {
-        inCodeBlock = !inCodeBlock;
-        continue;
-      }
-      if (inCodeBlock) {
+      if (codeLines.has(i + 1)) {
         continue;
       }
       // Headings are anchor targets; pure nav/TOC items mirror them.

--- a/.rules/no-unapproved-terms.js
+++ b/.rules/no-unapproved-terms.js
@@ -67,18 +67,14 @@ module.exports = {
   parser: 'markdownit',
   function: function rule(params, onError) {
     const lines = params.lines;
-    let inCodeBlock = false;
+    const codeLines = require('./code-lines')(params);
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const trimmed = line.trim();
 
       // Toggle fenced code state and never inspect code content.
-      if (/^(`{3,}|~{3,})/.test(trimmed)) {
-        inCodeBlock = !inCodeBlock;
-        continue;
-      }
-      if (inCodeBlock) {
+      if (codeLines.has(i + 1)) {
         continue;
       }
 


### PR DESCRIPTION
Replace the hand-rolled fence toggle (/^(`{3,}|~{3,})/ flipping a boolean) in all eight STE rules with a shared .rules/code-lines.js helper that derives code-block line numbers from the markdown-it token stream (fence + code_block tokens). The rules already declare parser: 'markdownit'.

Fixes two latent bugs the toggle had:
- mixed fences: a ``` line inside a ~~~ block flipped the state, so prose after the block was wrongly treated as code and its violations were missed;
- indented code: 4-space code blocks have no fence and were never skipped, so contractions/please/terms inside them would falsely flag.

Rules updated: no-contractions, no-please, no-unapproved-terms, no-generic-admonition-title, no-md-link-extension, no-markdown-tables, max-sentence-length, no-horizontal-rule.

Verified with a fixture exercising both edge cases (a ~~~ block containing a stray ``` fence, then prose, then a 4-space indented block): code regions are skipped and only the genuine prose violations flag. Full-corpus npm run lint stays 0 and ./bin/mklint strict build passes.