### PR TITLE
docs: document Pro lag compensation for long-paused partitions

### DIFF
--- a/Infrastructure/Monitoring-and-Logging.md
+++ b/Infrastructure/Monitoring-and-Logging.md
@@ -278,6 +278,55 @@ Karafka::App.monitor.subscribe('statistics.emitted') do |event|
 end
 ```
 
+### Lag Compensation for Long-Paused Partitions (Pro)
+
+`librdkafka` updates watermark offsets and consumer lag only from fetch responses. A paused partition does **not** fetch, so once it has stayed paused for a while, its watermark offset and `consumer_lag` values stop changing in `statistics.emitted` and remain frozen for as long as the pause lasts. The growing `consumer_lag_fd` freeze duration described above makes this visible. Any dashboard, alert, or Web UI view built on those values then shows stale lag for the paused partition, even though the partition may be falling further behind.
+
+Karafka Pro can compensate for this. When enabled, it periodically refreshes the watermark offsets and lags of long-paused partitions through the running consumer connection (a single batched `ListOffsets` query) and overlays the refreshed values onto the emitted statistics, so long-paused partitions report an accurate, moving lag.
+
+The feature is disabled by default and controlled by two internal settings:
+
+<table>
+  <tr>
+    <th>Setting</th>
+    <th>Default</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>config.internal.statistics.consumer_groups.lag_compensation.interval</code></td>
+    <td><code>0</code></td>
+    <td>How often, in milliseconds, to refresh the watermarks and lags of long-paused partitions at most. <code>0</code> disables the feature entirely.</td>
+  </tr>
+  <tr>
+    <td><code>config.internal.statistics.consumer_groups.lag_compensation.pause_age</code></td>
+    <td><code>30_000</code></td>
+    <td>How long, in milliseconds, a partition needs to stay continuously paused before it qualifies for compensation. Short pause and resume cycles reset the clock and never qualify. The minimum accepted value is <code>5_000</code>, because statistics of partitions paused for a shorter time are fresh enough that compensating them is pointless.</td>
+  </tr>
+</table>
+
+To enable it, set the interval to a value greater than zero. The compensated values are overlaid onto the same `statistics.emitted` payload, so `statistics.interval.ms` must be enabled as well:
+
+```ruby
+class KarafkaApp < Karafka::App
+  setup do |config|
+    config.kafka = {
+      'bootstrap.servers': 'localhost:9092',
+      'statistics.interval.ms': 5_000
+    }
+
+    # Refresh the lag of partitions paused for 30s or more, at most every 30s
+    config.internal.statistics.consumer_groups.lag_compensation.interval = 30_000
+    config.internal.statistics.consumer_groups.lag_compensation.pause_age = 30_000
+  end
+end
+```
+
+When a partition resumes, the refreshing stops, but the last compensated values are kept until the post-resume `librdkafka` fetches catch up. This hands over to the live statistics only once the fresh fetch values are available, instead of the emitted lag snapping back to the frozen pre-resume value in the meantime. The kept values are dropped in bulk on the next rebalance.
+
+!!! warning "Compensated Lag Can Overstate `read_committed` Lag During a Transaction"
+
+    The refresh uses the batched `ListOffsets` API, which resolves the end offset to the high watermark regardless of the consumer isolation level. While a transaction is in flight on a paused partition, the compensated lag can transiently overstate the `read_committed` lag by the number of uncommitted messages. It self-corrects once the transaction resolves. Non-transactional topics are unaffected.
+
 ## Web UI monitoring and error tracking
 
 Karafka Web UI is a user interface for the [Karafka framework](https://github.com/karafka/karafka). The Web UI provides a convenient way for developers to monitor and manage their Karafka-based applications, without the need to use the command line or third party software. It does **not** require any additional database beyond Kafka itself.

--- a/Upgrades/Karafka/2.6.md
+++ b/Upgrades/Karafka/2.6.md
@@ -6,7 +6,7 @@
 
 Karafka 2.6 is a significant release built around one central theme: preparing the internals for **Kafka Share Groups** (KIP-932). To support a fundamentally new group type alongside the existing consumer group model, a large portion of the processing, routing, connection, and instrumentation layers has been reorganized into consistent namespaces. This was the mandatory first step - the internal consistency work had to land before any Share Group functionality could be layered on top.
 
-Beyond the structural groundwork, 2.6 ships a redesigned Declarative Topics system, a new low-level partition offset query API, and dynamic worker pool scaling.
+Beyond the structural groundwork, 2.6 ships a redesigned Declarative Topics system, a new low-level partition offset query API, dynamic worker pool scaling, and Pro lag compensation for long-paused partitions.
 
 !!! tip "Pro & Enterprise Upgrade Support"
 
@@ -295,6 +295,21 @@ end
 !!! note "Relationship with `config.concurrency`"
 
     `config.concurrency` sets the initial pool size at boot. `#scale` adjusts the running pool at runtime without affecting the configuration value. After a restart, the pool will initialize again from `config.concurrency`.
+
+## Lag Compensation for Long-Paused Partitions (Pro)
+
+`librdkafka` refreshes watermark offsets and consumer lag only from fetch responses, so a partition that stays paused for a long time reports frozen lag in `statistics.emitted` (and in anything built on it, including the Web UI). Karafka Pro can now compensate for this: when enabled, it periodically refreshes the watermarks and lags of long-paused partitions through the running consumer connection and overlays them onto the emitted statistics.
+
+The feature is opt-in and disabled by default. Enable it by setting a refresh interval (`statistics.interval.ms` must also be enabled):
+
+```ruby
+# How often (ms) to refresh at most; 0 (default) disables the feature
+config.internal.statistics.consumer_groups.lag_compensation.interval = 30_000
+# How long (ms) a partition must stay paused to qualify (default 30_000, min 5_000)
+config.internal.statistics.consumer_groups.lag_compensation.pause_age = 30_000
+```
+
+No action is required to upgrade - the feature stays off unless you enable it. See [Monitoring and Logging](Infrastructure-Monitoring-and-Logging#lag-compensation-for-long-paused-partitions-pro) for the full behavior, including the resume hand-off and the transactional `read_committed` edge case.
 
 ## Ractors Deferred from 2.6
 


### PR DESCRIPTION
The 2.6 Pro lag-compensation feature was only in the component changelog. librdkafka refreshes watermark offsets and consumer lag solely from fetch responses, so long-paused partitions report frozen lag in statistics.emitted; the compensator periodically refreshes them via the running consumer connection and overlays the values onto the emitted statistics.

- Add a 'Lag Compensation for Long-Paused Partitions (Pro)' section to Infrastructure/Monitoring-and-Logging.md under the statistics.emitted docs: the problem, the two internal settings (lag_compensation.interval / pause_age), a config example, the post-resume hand-off, and the read_committed transaction edge case.
- Add a concise section plus an intro mention to the Karafka 2.6 upgrade guide, linking to the full docs.

Verified: npm run lint clean (passes the enforced STE rules), ./bin/mklint strict build passes (the cross-page anchor resolves).