### PR TITLE
Fix Web UI 1.0 CSRF doc: only Sec-Fetch-Site: same-origin is accepted

### DIFF
--- a/Upgrades/Web-UI/1.0.md
+++ b/Upgrades/Web-UI/1.0.md
@@ -18,7 +18,9 @@ The CSRF protection mechanism has been replaced. The previous token-based approa
 
 For most users this is transparent - all modern browsers automatically include the `Sec-Fetch-Site` header and the new approach requires no changes to your application.
 
-If you have non-browser clients, custom HTTP clients, or integration tests that send requests directly to the Web UI without browser-standard headers, those clients will need to include the `Sec-Fetch-Site: same-origin` (or `same-site`) header. Requests lacking this header will be rejected as potential cross-site forgeries.
+Only unsafe HTTP methods (`POST`, `PUT`, `PATCH`, `DELETE`) are checked; `GET` and `HEAD` requests are always allowed regardless of the header.
+
+If you have non-browser clients, custom HTTP clients, or integration tests that issue such requests directly to the Web UI without browser-standard headers, those clients must include the `Sec-Fetch-Site: same-origin` header. Only the `same-origin` value is accepted - requests with `same-site`, `cross-site`, or with the header missing entirely will be rejected as potential cross-site forgeries.
 
 ## Dynamic Worker Count in the UI
 


### PR DESCRIPTION
The 1.0 upgrade guide stated non-browser clients could send `Sec-Fetch-Site: same-origin` (or `same-site`). The actual `sec_fetch_site_csrf` plugin behavior (karafka-web base.rb, verified by base_csrf_test.rb) rejects `same-site`, `cross-site`, and a missing header for unsafe methods; only `same-origin` passes. GET/HEAD are always allowed. Corrected the wording accordingly.