### PR TITLE
Update pause config docs to the nested config.pause.* namespace

### DIFF
--- a/Basics/FAQ/Error-Handling-and-DLQ.md
+++ b/Basics/FAQ/Error-Handling-and-DLQ.md
@@ -5,7 +5,7 @@
 1. [What will happen when a message is dispatched to a dead letter queue topic that does not exist?](#what-will-happen-when-a-message-is-dispatched-to-a-dead-letter-queue-topic-that-does-not-exist)
 1. [How can I make Karafka not retry processing, and what are the implications?](#how-can-i-make-karafka-not-retry-processing-and-what-are-the-implications)
 1. [What happens if an error occurs while consuming a message in Karafka? Will the message be marked as not consumed and automatically retried?](#what-happens-if-an-error-occurs-while-consuming-a-message-in-karafka-will-the-message-be-marked-as-not-consumed-and-automatically-retried)
-1. [Why do I see hundreds of repeat exceptions with `pause_with_exponential_backoff` enabled?](#why-do-i-see-hundreds-of-repeat-exceptions-with-pause_with_exponential_backoff-enabled)
+1. [Why do I see hundreds of repeat exceptions with exponential backoff enabled?](#why-do-i-see-hundreds-of-repeat-exceptions-with-exponential-backoff-enabled)
 1. [Why does the Dead Letter Queue (DLQ) use the default deserializer instead of the one specified for the original topic in Karafka?](#why-does-the-dead-letter-queue-dlq-use-the-default-deserializer-instead-of-the-one-specified-for-the-original-topic-in-karafka)
 1. [What should I consider when manually dispatching messages to the DLQ in Karafka?](#what-should-i-consider-when-manually-dispatching-messages-to-the-dlq-in-karafka)
 1. [How can I handle `dispatch_to_dlq` method errors when using the same consumer for a topic and its DLQ?](#how-can-i-handle-dispatch_to_dlq-method-errors-when-using-the-same-consumer-for-a-topic-and-its-dlq)
@@ -150,9 +150,9 @@ However, be aware of the potential risks associated with these approaches. In th
 
 In Karafka's default flow, if an error occurs during message consumption, the processing will pause at the problematic message, and attempts to consume it will automatically retry with an exponential backoff strategy. This is typically effective for resolving transient issues (e.g., database disconnections). However, it may not be suitable for persistent message-specific problems, such as corrupted JSON. In such cases, Karafka's Dead Letter Queue feature can be used. This feature allows a message to be retried several times before it is moved to a Dead Letter Queue (DLQ), enabling the process to continue with subsequent messages. More information on this can be found in the [Dead Letter Queue Documentation](Consumer-Groups-Dead-Letter-Queue).
 
-## Why do I see hundreds of repeat exceptions with `pause_with_exponential_backoff` enabled?
+## Why do I see hundreds of repeat exceptions with exponential backoff enabled?
 
-When `pause_with_exponential_backoff` is enabled, the timeout period for retries doubles after each attempt, but this does not prevent repeated exceptions from occurring. With `pause_max_timeout` set to the default 30 seconds, an unaddressed exception can recur up to 120 times per hour. This frequent repetition happens because the system continues to retry processing until the underlying issue is resolved.
+When `config.pause.with_exponential_backoff` is enabled, the timeout period for retries doubles after each attempt, but this does not prevent repeated exceptions from occurring. With `config.pause.max_timeout` set to the default 30 seconds, an unaddressed exception can recur up to 120 times per hour. This frequent repetition happens because the system continues to retry processing until the underlying issue is resolved.
 
 ## Why does the Dead Letter Queue (DLQ) use the default deserializer instead of the one specified for the original topic in Karafka?
 

--- a/Consumer-Groups/Error-Handling-and-Back-Off-Policy.md
+++ b/Consumer-Groups/Error-Handling-and-Back-Off-Policy.md
@@ -39,7 +39,7 @@ When processing messages from a Kafka topic, your code may raise any exception i
 - The message being processed is somehow malformed or is in an invalid format.
 - You are using external resources such as a database or a network API that are temporarily unavailable.
 
-Your exception will propagate to the framework if not caught and handled within your application code. Karafka will stop processing messages from this topic partition, back off, and wait for a given time defined by the `pause_timeout` setting. This allows the consumer to continue processing messages from other partitions that may not be impacted by the problem while still making sure not to drop the original message. After that time, it will **retry**, processing the same message again. Single Kafka topic partition messages must be processed in order. That is why Karafka will **never** skip any messages.
+Your exception will propagate to the framework if not caught and handled within your application code. Karafka will stop processing messages from this topic partition, back off, and wait for a given time defined by the `config.pause.timeout` setting. This allows the consumer to continue processing messages from other partitions that may not be impacted by the problem while still making sure not to drop the original message. After that time, it will **retry**, processing the same message again. Single Kafka topic partition messages must be processed in order. That is why Karafka will **never** skip any messages.
 
 ### Retryable Methods
 
@@ -187,7 +187,7 @@ end
 
 ### Exponential Backoff
 
-Karafka is configured with `pause_with_exponential_backoff` enabled (`true`) by default. This configuration doubles the timeout period after each pause until a message from the partition is processed successfully. To prevent the timeout from extending indefinitely, `pause_max_timeout` can be set to your preferred maximum duration. By default, this maximum timeout is set to 30 seconds.
+Karafka is configured with `config.pause.with_exponential_backoff` enabled (`true`) by default. This configuration doubles the timeout period after each pause until a message from the partition is processed successfully. To prevent the timeout from extending indefinitely, `config.pause.max_timeout` can be set to your preferred maximum duration. By default, this maximum timeout is set to 30 seconds.
 
 Regardless of the error's nature, the Monitoring and Logging feature can track any issues encountered during operation.
 

--- a/Pro/Consumer-Groups/Granular-Backoffs.md
+++ b/Pro/Consumer-Groups/Granular-Backoffs.md
@@ -8,11 +8,11 @@ The Granular Backoffs feature enables you to customize backoff settings for each
 
 Karafka, by default, includes three configuration-level settings for computing pause time:
 
-1. `pause_timeout`: This setting determines the waiting period after a processing error. The wait time is expressed in milliseconds, and the default is set to 1000 milliseconds (or 1 second).
+1. `config.pause.timeout`: This setting determines the waiting period after a processing error. The wait time is expressed in milliseconds, and the default is set to 1000 milliseconds (or 1 second).
 
-2. `pause_max_timeout`: This is the maximum time to wait in an exponential backoff scenario. The wait time is in milliseconds; by default, it is set to 30,000 milliseconds (or 30 seconds).
+2. `config.pause.max_timeout`: This is the maximum time to wait in an exponential backoff scenario. The wait time is in milliseconds; by default, it is set to 30,000 milliseconds (or 30 seconds).
 
-3. `pause_with_exponential_backoff`: This Boolean setting determines whether or not the system should use exponential backoff. The default setting is true, meaning that the system will use an exponential backoff approach by default.
+3. `config.pause.with_exponential_backoff`: This Boolean setting determines whether or not the system should use exponential backoff. The default setting is true, meaning that the system will use an exponential backoff approach by default.
 
 However, these default settings are not set in stone. You can override them on a per-topic basis using the routing `#pause` method. This method accepts the following keyword arguments:
 


### PR DESCRIPTION
Karafka 2.6 removed the flat global pause settings (config.pause_timeout, config.pause_max_timeout, config.pause_with_exponential_backoff) in favor of the nested config.pause.* namespace. Update the docs that still named them flat:

- Pro/Granular-Backoffs: the configuration-level settings list
- Consumer-Groups/Error-Handling-and-Back-Off-Policy: setting references
- Basics/FAQ/Error-Handling-and-DLQ: setting references (the exponential backoff FAQ heading was reworded to drop the setting token; its anchor and the TOC link were updated to match)

The per-topic override via the routing #pause method is unchanged.