### PR TITLE
Document karafka-rdkafka 0.28.0 requirement and 2.6 behavioral changes

### DIFF
--- a/Upgrades/Karafka/2.6.md
+++ b/Upgrades/Karafka/2.6.md
@@ -34,6 +34,12 @@ config.pause.max_timeout = 30_000
 config.pause.with_exponential_backoff = true
 ```
 
+### Minimum `karafka-rdkafka` Version
+
+Karafka 2.6 requires `karafka-rdkafka` `>= 0.28.0`. This version exposes `Rdkafka::Consumer#list_offsets` and rebuilds consumer `#lag` on top of it, so lag reads issue a single batched end-offsets query instead of one watermark roundtrip per partition.
+
+If you pin `karafka-rdkafka` in your `Gemfile`, make sure the constraint allows `0.28.0` or newer. Precompiled native gems are shipped for common platforms, so most deployments need no build toolchain; only source installs or unsupported platforms compile `librdkafka` from source.
+
 ## Karafka Web UI Promoted to 1.0
 
 Karafka Web UI reaches its 1.0 release alongside Karafka 2.6. The 0.x versioning was always a conservative choice, not a reflection of stability - Web UI has been production-ready and free of major breaking changes for a long time, and there is no longer a reason to signal otherwise through a sub-1.0 version number.
@@ -323,11 +329,36 @@ Several internal admin operations that previously issued N sequential per-partit
 - The time-based offset resolution fallback in `Admin::ConsumerGroups#seek` now uses a single batch call.
 - Pro `Iterator::TplBuilder` negative offset resolution is now handled with three total calls regardless of partition count.
 
+## Behavioral Changes
+
+These changes do not require code updates, but they alter runtime behavior. Review them and verify your monitoring and error handling after upgrading.
+
+### Lag Reporting
+
+Consumer lag is now computed from a single batched `list_offsets` query (via `karafka-rdkafka` `0.28.0`) instead of a per-partition watermark roundtrip. Under normal conditions the reported values are equivalent, but note that `:latest` resolves to the high watermark **regardless of isolation level**. On transactional topics this means lag can transiently include uncommitted messages that a `read_committed` consumer will never process, temporarily overstating the lag until the in-flight transaction resolves.
+
+If you alert on lag thresholds, sanity-check your dashboards after upgrading.
+
+### Error Handling for Non-`StandardError` Exceptions
+
+Errors that are not `StandardError` descendants (for example `ScriptError`, `SystemStackError`) are no longer skipped. They now flow through the normal retry / pause / DLQ path like any other consumption error.
+
+Process-critical errors (`SystemExit`, `SignalException`, `NoMemoryError`) are handled separately: they are recorded, keep the partition paused, and trigger a graceful shutdown via the auto-subscribed `Instrumentation::CriticalErrorsListener` instead of being retried or dispatched to the DLQ. The set is configurable via `config.internal.processing.critical_errors`.
+
+If your consumers can raise non-`StandardError` exceptions, the outcome now differs from 2.5.
+
+### Swarm Shutdown Grace Period
+
+The swarm supervisor's `SHUTDOWN_GRACE_PERIOD` was increased from 1 second to 15 seconds, giving forked nodes enough time to finish their post-`shutdown_timeout` cleanup before the supervisor forcefully terminates them. Shutdowns of unresponsive swarm nodes may therefore take longer than in 2.5.
+
 ## Summary of Actions Required
 
-For most applications, the upgrade from 2.5 to 2.6 requires only one action:
+For most applications, the upgrade from 2.5 to 2.6 requires two actions:
 
 - Update `config.pause_timeout`, `config.pause_max_timeout`, and `config.pause_with_exponential_backoff` to `config.pause.timeout`, `config.pause.max_timeout`, and `config.pause.with_exponential_backoff`.
+- Ensure your `karafka-rdkafka` dependency allows `>= 0.28.0`.
+
+Additionally, review the Behavioral Changes section above for runtime differences (lag reporting, non-`StandardError` handling, and swarm shutdown timing) that do not require code changes but may affect monitoring or error handling.
 
 If your code references internal Karafka classes by constant path, review the namespace moves in the Internal Namespace Reorganization section above.
 


### PR DESCRIPTION
Add to the Karafka 2.6 upgrade guide items that were missing:
- karafka-rdkafka >= 0.28.0 requirement (Breaking Changes + Actions summary)
- Behavioral Changes section covering lag reporting (batched list_offsets; transactional read_committed caveat), non-StandardError / process-critical error handling, mark_as_consumed/commit_offsets returning false on lost partitions, and the swarm shutdown grace period increase (1s -> 15s).