### PR TITLE
Remove 2.6 not-yet-released notices

### DIFF
--- a/Infrastructure/Declarative-Topics.md
+++ b/Infrastructure/Declarative-Topics.md
@@ -1,7 +1,3 @@
-!!! warning "New Format Available in 2.6.0.rc1 Only"
-
-    The new standalone declarative topics format described in this document is currently available only in `karafka 2.6.0.rc1`. It is not yet part of a stable Karafka release, and details may change before the final `2.6` release. If you are on a stable Karafka version, use the [Legacy Routing-Based Configuration](#legacy-routing-based-configuration) format described below for now.
-
 Karafka allows you to manage your topics in three ways:
 
 - Using the built-in [Declarative Topics](Infrastructure-Declarative-Topics) standalone DSL + CLI functionality (recommended)

--- a/Upgrades/Karafka/2.6.md
+++ b/Upgrades/Karafka/2.6.md
@@ -1,9 +1,5 @@
 # Upgrading to Karafka 2.6
 
-!!! warning "Not Yet Released"
-
-    Karafka 2.6 has **not** been released yet. This document is a work in progress and reflects the planned changes. Details may change before the final release.
-
 Karafka 2.6 is a significant release built around one central theme: preparing the internals for **Kafka Share Groups** (KIP-932). To support a fundamentally new group type alongside the existing consumer group model, a large portion of the processing, routing, connection, and instrumentation layers has been reorganized into consistent namespaces. This was the mandatory first step - the internal consistency work had to land before any Share Group functionality could be layered on top.
 
 Beyond the structural groundwork, 2.6 ships a redesigned Declarative Topics system, a new low-level partition offset query API, dynamic worker pool scaling, and Pro lag compensation for long-paused partitions.


### PR DESCRIPTION
Karafka 2.6 is being released, so drop the 'Not Yet Released' warning in the upgrade guide and the '2.6.0.rc1 Only' warning in the declarative topics documentation.